### PR TITLE
Add PGo `raftkvs` and `locksvc` prompts

### DIFF
--- a/data/invariant_templates/locksvc/invariants.yaml
+++ b/data/invariant_templates/locksvc/invariants.yaml
@@ -1,0 +1,62 @@
+invariants:
+  - name: "LockSafety"
+    natural_language: "At most one client holds the lock at any time."
+    tla_example: |
+      LockSafety ==
+          \A i, j \in ClientSet:
+              (/\ i # j
+               /\ hasLock[i])
+              => ~ hasLock[j]
+
+  - name: "NoPriorityInversion"
+    natural_language: "A later client cannot finish its critical section before an earlier waiter due to inversion."
+    tla_example: |
+      NoPriorityInversion ==
+          \A i, j \in NodeSet :
+              i # j =>
+              [](
+                  /\ pc[i] = "acquireLock"
+                  /\ pc[j] = "criticalSection"
+                  => ~<>(
+                      /\ pc[i] = "unlock"
+                      /\ pc[j] = "criticalSection"
+                  )
+              )
+
+  - name: "ProgressOK"
+    type: "liveness"
+    scope: "per-node"
+    natural_language: "Each node that tries to acquire eventually enters CS, then eventually unlocks."
+    tla_example: |
+      ProgressOK(i) == pc[i] = "acquireLock" ~> (pc[i] = "criticalSection" ~> pc[i] = "unlock")
+
+  - name: "SystemLiveness"
+    type: "liveness"
+    natural_language: "All nodes satisfy ProgressOK."
+    tla_example: |
+      Liveness == \A i \in NodeSet: ProgressOK(i)
+  
+  - name: "ServerIsIdle"
+    type: "liveness"
+    natural_language: "Server may idle (no state change), allowing stuttering steps."
+    tla_example: |
+      ServerIsIdle ==
+          \E self \in ServerSet :
+              /\ pc[self] = "serverReceive"
+              /\ UNCHANGED vars
+
+  - name: "SpecNoDeadlock"
+    type: "liveness"
+    natural_language: "Initialization, step relation with idling, and weak fairness prevent deadlock."
+    tla_example: |
+      SpecNoDeadlock ==
+          /\ Init
+          /\ [][Next \/ ServerIsIdle]_vars
+          /\ \A self \in ServerSet : WF_vars(Server(self))
+          /\ \A self \in ClientSet : WF_vars(client(self))
+
+
+metadata:
+  total_invariants: 6 
+  safety_invariants: 2
+  liveness_invariants: 4

--- a/data/invariant_templates/raftkvs/invariants.yaml
+++ b/data/invariant_templates/raftkvs/invariants.yaml
@@ -1,0 +1,124 @@
+# High-Quality Invariants for PGo Raft KV store Systems
+# Based on deep analysis of PGo-generated raftkvs.go implementation with concrete state predicates
+
+invariants:
+  - name: "LimitTerm"
+    type: "safety"
+    natural_language: "Each node's term is strictly below MaxTerm"
+    tla_example: |
+      LimitTerm == \A i \in ServerSet: currentTerm[i] < MaxTerm
+
+  - name: "LimitCommitIndex"
+    type: "safety"
+    natural_language: "Each node's commit index is strictly below MaxCommitIndex"
+    tla_example: |
+      LimitCommitIndex == \A i \in ServerSet: commitIndex[i] < MaxCommitIndex
+
+  - name: "LimitNodeFailure"
+    type: "safety"
+    natural_language: "At most MaxNodeFail nodes can be disabled"
+    tla_example: |
+      LimitNodeFailure == Cardinality({i \in ServerSet: \lnot network[i].enabled}) <= MaxNodeFail
+
+  # Core Raft safety
+  - name: "ElectionSafety"
+    type: "safety"
+    natural_language: "No two leaders exist in the same term"
+    tla_example: |
+      ElectionSafety == \lnot (\E i, j \in ServerSet:
+                                  /\ i /= j
+                                  /\ currentTerm[i] = currentTerm[j]
+                                  /\ state[i] = Leader
+                                  /\ state[j] = Leader)
+
+  - name: "LogMatching"
+    type: "safety"
+    natural_language: "Same (index,term) implies identical prefixes"
+    tla_example: |
+      LogMatching == \A i, j \in ServerSet:
+                        \A k \in 1..Min({Len(log[i]), Len(log[j])}):
+                            log[i][k].term = log[j][k].term
+                              => SubSeq(log[i], 1, k) = SubSeq(log[j], 1, k)
+
+  - name: "LeaderCompleteness"
+    type: "safety"
+    natural_language: "Committed entries appear in leaders with ≥ that term"
+    tla_example: |
+      LeaderCompleteness == \A i \in ServerSet:
+                              \A logIdx \in DOMAIN log[i]:
+                                logIdx <= commitIndex[i] =>
+                                  \A j \in ServerSet:
+                                    state[j] = Leader /\ currentTerm[j] >= log[i][logIdx].term =>
+                                      /\ logIdx \in DOMAIN log[j]
+                                      /\ log[i][logIdx] = log[j][logIdx]
+
+  - name: "StateMachineSafety"
+    type: "safety"
+    natural_language: "Committed prefixes are identical across servers"
+    tla_example: |
+      StateMachineSafety == \A i, j \in ServerSet:
+                               \A k \in 1..Min({commitIndex[i], commitIndex[j]}):
+                                 log[i][k] = log[j][k]
+
+  # Model-specific safety
+  - name: "ApplyLogConsistency"
+    type: "safety"
+    natural_language: "Equal commit index implies equal state machine state & domain"
+    tla_example: |
+      ApplyLogOK == \A i, j \in ServerSet:
+                       commitIndex[i] = commitIndex[j] =>
+                         /\ sm[i] = sm[j]
+                         /\ smDomain[i] = smDomain[j]
+
+  - name: "PersistentLogEquality"
+    type: "safety"
+    natural_language: "Volatile and persistent logs match"
+    tla_example: |
+      plogOK == \A i \in ServerSet: log[i] = plog[i]
+
+  - name: "TermBounded"
+    type: "safety"
+    natural_language: "Terms never exceed MaxTerm"
+    tla_example: |
+      TermOK == \A i \in ServerSet: currentTerm[i] <= MaxTerm
+
+  - name: "CommitIndexBounded"
+    type: "safety"
+    natural_language: "Commit index never exceeds MaxCommitIndex"
+    tla_example: |
+      CommitIndexOK == \A i \in ServerSet: commitIndex[i] <= MaxCommitIndex
+
+  - name: "NodeFailureBounded"
+    type: "safety"
+    natural_language: "Disabled nodes bounded by MaxNodeFail + 1"
+    tla_example: |
+      NodeFailOK == Cardinality({i \in ServerSet: \lnot network[i].enabled}) <= MaxNodeFail+1
+
+  - name: "LeaderAppendOnly"
+    type: "safety"
+    natural_language: "Leaders only append to their logs"
+    tla_example: |
+      LeaderAppendOnly == [][\A i \in ServerSet:
+                                (state[i] = Leader /\ state'[i] = Leader)
+                                  => log[i] = SubSeq(log'[i], 1, Len(log[i]))]_vars
+
+  # Liveness
+  - name: "ClientsLiveness"
+    type: "liveness"
+    natural_language: "Clients that receive a response progress to the loop"
+    tla_example: |
+      ClientRcvResp(i) == pc[i] = "rcvResp" ~> pc[i] = "clientLoop"
+      ClientsOK == \A i \in ClientSet: ClientRcvResp(i)
+
+  - name: "ElectionLiveness"
+    type: "liveness"
+    natural_language: "Eventually some server becomes Leader"
+    tla_example: |
+      ElectionLiveness == []<>(\E i \in ServerSet: state[i] = Leader)
+
+metadata:
+  total_invariants: 15
+  safety_invariants: 10
+  liveness_invariants: 2
+  core_raft_invariants: 4   # ElectionSafety, LogMatching, LeaderCompleteness, StateMachineSafety
+  etcd_specific_invariants: 0

--- a/tla_eval/tasks/locksvc/prompts/agent_based.txt
+++ b/tla_eval/tasks/locksvc/prompts/agent_based.txt
@@ -1,0 +1,46 @@
+You are an expert TLA+ specification specialist with extensive experience in concurrent systems and distributed locking services.
+
+I need you to fix errors in a TLA+ specification for a {system_type} lock system.
+
+## Original Task Description
+{description}
+
+## Current TLA+ Specification (with errors)
+```tla
+{current_specification}
+```
+
+## Validation Errors Found
+**Error Summary:**
+{error_summary}
+
+**Detailed Syntax Errors:**
+{syntax_errors}
+
+**Detailed Semantic Errors:**
+{semantic_errors}
+
+**Full Validation Output:**
+```
+{validation_output}
+```
+
+## Correction Instructions
+This is correction attempt {attempt_number} of {max_attempts}.
+
+Based on the validation errors above, please fix the TLA+ specification to ensure it compiles correctly while maintaining the intended locking semantics.
+
+Key considerations for lock correctness:
+1. Ensure proper modeling of exclusive access and mutual exclusion
+2. Maintain thread ownership and safety properties
+3. Fix any syntax errors while preserving the locking logic
+4. Ensure all variables and operators are properly declared
+5. Preserve WaitQueue-based blocking and fairness mechanisms
+6. **MANDATORY**: Include weak fairness in Spec definition using pattern: Spec == Init /\ [][Next]_Vars /\ WF_Vars(Next)
+
+CRITICAL OUTPUT REQUIREMENTS:
+1. The MODULE name must remain exactly "locksvc" (---- MODULE locksvc ----)
+2. Return ONLY the corrected TLA+ specification code - no markdown code blocks
+3. Do not include explanations, just the fixed specification
+4. Start your response directly with: ---- MODULE locksvc ----
+5. End your response with the closing ====

--- a/tla_eval/tasks/locksvc/prompts/direct_call.txt
+++ b/tla_eval/tasks/locksvc/prompts/direct_call.txt
@@ -1,0 +1,48 @@
+You are an expert in formal verification and TLA+ specifications with deep expertise in concurrent systems and synchronization primitives.
+
+Convert the following PGo-generated distributed lock service source code to a comprehensive TLA+ specification.
+
+System: Locksvc distributed locking service
+Focus: {focus}
+
+Source Code from {file_path}:
+```go
+{source_code}
+```
+
+Lock modeling requirements:
+
+MANDATORY CORE ACTIONS (must include all):
+1. 【Lock/Unlock Requests】Client sends lock() request, receives GrantMsg, then sends unlock() on release
+2. 【Server Queue Handling】Server enqueues LockMsg senders, grants lock immediately if queue empty, dequeues on UnlockMsg
+3. 【Grant Dispatch】Server sends GrantMsg to the head of the queue when a lock is available
+4. 【Client Critical Section】Client enters criticalSection only after receiving GrantMsg, sets hasLock = true
+5. 【Mailbox Communication】ReliableLink read/write over bag-based mailboxes (message send/receive abstraction)
+
+EXPLICITLY EXCLUDED (do not model):
+- Debug formatting and interface implementations
+- Thread ownership tracking complexities beyond basic exclusion
+- Advanced guard type variations (lifetime management complexities)
+- Hardware memory ordering details (Acquire/Release ordering - handle at logical atomicity level only)
+- Detailed wait_until() retry loop implementation (abstract as waiting state)
+
+REQUIRED BEHAVIORAL SCOPE:
+- Boolean ownership state tracked via hasLock[client]: false (unlocked) ↔ true (locked)
+- Exclusive access enforcement: at most one client in criticalSection
+- FIFO-like queue maintained at server (Append on LockMsg, Tail on UnlockMsg, Head granted)
+- Client can reacquire lock only after unlock message is processed
+- Lock acquisition: blocking until GrantMsg arrives vs non-blocking network sends
+- Automatic GrantMsg dispatch ensures queued clients eventually progress
+- Thread (client) may be waiting in acquireLock state until GrantMsg received
+
+Generate a TLA+ specification that accurately models the lock service's concurrent behavior.
+
+CRITICAL OUTPUT REQUIREMENTS:
+1. The MODULE name must be exactly "locksvc" (---- MODULE locksvc ----)
+2. Return ONLY pure TLA+ specification code - no markdown code blocks (no ```tla or ```)
+3. Do not include any explanations, comments, or formatting markers
+4. Start your response directly with: ---- MODULE locksvc ----
+5. End your response with the closing ====
+6. **DO NOT define invariants** (like MutualExclusion, Invariant, etc.) - only include TypeOK, Init, actions, Next, Spec, and Vars
+7. **MUST include EXTENDS statement**: The specification must extend at least these modules: TLC, Sequences, SequencesExt, Naturals, FiniteSets, Bags
+8. **MANDATORY Spec Definition with Fairness**: The Spec definition MUST include appropriate fairness assumptions (e.g., WF_Vars for unlock operations or overall progress) to ensure liveness properties.

--- a/tla_eval/tasks/locksvc/prompts/phase2_config.txt
+++ b/tla_eval/tasks/locksvc/prompts/phase2_config.txt
@@ -1,0 +1,30 @@
+You are a TLA+ expert. Generate a complete TLC configuration file (.cfg) for the locking specification that can be directly saved and used for model checking.
+
+## Input Specification:
+
+$tla_spec
+
+## Generated Invariants:
+
+$invariants
+
+## Requirements:
+
+1. **Analyze the specification** to identify the main specification name and all declared constants
+2. **Generate complete .cfg file content** with SPECIFICATION, CONSTANTS, and INVARIANT/PROPERTY sections
+3. **Use small values for constants** to ensure efficient model checking (2-3 threads, small integers)
+4. **Only include invariants that are actually defined in the specification** - scan the TLA+ specification to check which invariants are defined. If an invariant name is provided but not defined in the specification, do NOT include it in the .cfg file. For included invariants, check if they use temporal operators (~>, <>) and put those in PROPERTY section instead of INVARIANT
+5. **Output ONLY the raw .cfg file content** - no explanations, no markdown, no code blocks
+
+## Example Output Format:
+
+SPECIFICATION SpecName
+
+CONSTANTS
+    ...
+INVARIANT
+    ...
+PROPERTY
+    ...
+
+**CRITICAL: Your response must contain exactly ONE complete .cfg file. Do not repeat any sections. Start your response immediately with "SPECIFICATION" and include nothing else. Each invariant name must be on its own line. Stop immediately after the last invariant name with no additional text.**

--- a/tla_eval/tasks/locksvc/prompts/phase2_invariants.txt
+++ b/tla_eval/tasks/locksvc/prompts/phase2_invariants.txt
@@ -1,0 +1,21 @@
+You are a TLA+ expert. Analyze the following TLA+ distributed locking specification and generate meaningful invariants for model checking.
+
+## Input Specification:
+
+$tla_spec
+
+## Requirements:
+
+1. **Analyze the specification** to understand the distributed locking synchronization behavior and state variables
+2. **Check existing invariants** - DO NOT generate invariants with names that already exist in the specification
+3. **Generate 2-3 NEW key invariants** that capture important safety properties for lock synchronization
+4. **Use proper TLA+ syntax** for each invariant definition (Name == Expression)
+5. **Focus on mutual exclusion and deadlock prevention properties not already covered**
+6. **Output ONLY the raw invariant definitions** - no explanations, no markdown, no code blocks, no quotes
+
+## Expected Output Format:
+
+LockSafety == condition1
+SpecNoDeadlock == condition2
+
+**IMPORTANT: Your response must contain only valid TLA+ invariant definitions that do NOT already exist in the specification. Start immediately with the first NEW invariant definition and include nothing else. Do not wrap in quotes or code blocks.**

--- a/tla_eval/tasks/locksvc/prompts/phase3_invariant_implementation.txt
+++ b/tla_eval/tasks/locksvc/prompts/phase3_invariant_implementation.txt
@@ -1,0 +1,90 @@
+You are a TLA+ expert specializing in concurrent systems and synchronization primitives. Your task is to implement a set of expert-written invariants for the given TLA+ distributed locking specification.
+
+## Target Specification
+
+$tla_specification
+
+## Invariants to Implement
+
+$invariant_templates
+
+## Implementation Requirements
+
+1. **Deep Analysis**: First, thoroughly understand both the invariant template's semantic intent and the specification's modeling approach:
+   - What safety/liveness property does each template aim to verify?
+   - How does the specification represent states, operations, and concurrency?
+   - What are the semantic equivalents between template concepts and specification implementation?
+
+2. **Semantic Mapping**: For each invariant, identify the conceptual mapping between template and specification:
+   - Template `"acquiring"` state → Specification's lock acquisition states (e.g., `"req_lock"`, `"waiting"`)
+   - Template `"releasing"` state → Specification's lock release states  
+   - Template ownership variables → Specification's ownership representation (explicit variables or implicit via state)
+   - Template thread sets → Specification's thread/process constants
+
+3. **Creative Adaptation**: Translate the invariant while preserving its core semantic meaning:
+   - **DO NOT** simply replace variable names - understand the underlying logic
+   - **DO** redesign the predicate logic to fit the specification's modeling granularity
+   - **DO** use equivalent semantic concepts even if names/structures differ
+   - **PRESERVE** the original safety/liveness intent without weakening the property
+
+4. **TLA+ Property Type Constraints**:
+   
+   **FOR SAFETY PROPERTIES** (type: "safety"):
+   - **MUST** be STATE PREDICATES (describe single states only)
+   - **NEVER** use primed variables (`pc'`, `lock_state'`)
+   - **NEVER** use temporal operators (`[]`, `<>`, `~>`)
+   - **NEVER** reference actions (like `Lock(p)`, `Unlock(p)`) - only use state variables
+   - **ONLY** use unprimed variables (`pc[t]`, `lock_state`) and constants
+   - **CORRECT**: `MutualExclusion == Cardinality({p ∈ Proc : pc[p] = "critical"}) <= 1` 
+   - **INCORRECT**: `pc[t] = "acquiring" => pc'[t] = "critical"`  (has primed variable)
+   - **INCORRECT**: `pc[p] = "waiting" => Lock(p)`  (references action Lock)
+
+   **FOR LIVENESS PROPERTIES** (type: "liveness"): 
+   - **MUST** be TEMPORAL FORMULAS (describe execution traces)
+   - **MUST** use temporal operators (`<>`, `~>`) to express "eventually" or "leads-to"
+   - **MAY** use both primed and unprimed variables as needed
+   - **CORRECT**: `EventualAcquisition == ∀p ∈ Proc : (pc[p] = "waiting") ~> (pc[p] = "critical")` 
+   - **INCORRECT**: `EventualAcquisition == pc[t] = "waiting"`  (missing temporal aspect)
+
+5. **Constraint Compliance**:
+   - Use ONLY variables, constants, and operators that exist in the specification
+   - Generate complete, syntactically valid TLA+ invariant definitions
+   - Maintain the exact invariant names from templates
+
+6. **Output format**: Return a JSON object containing an array of complete TLA+ invariant definitions
+
+7. **EXACT naming requirement**: You MUST use the exact invariant names specified in the templates above. Do not create your own names.
+
+## Example Output Format
+
+```json
+{
+  "invariants": [
+    "MutualExclusion == Cardinality({t \\in Threads : pc[t] = \"critical\"}) <= 1",
+    "LockConsistency == (lock_state = TRUE) <=> (\\E t \\in Threads : pc[t] = \"critical\")",
+    "EventualAcquisition == \\A t \\in Threads : (pc[t] = \"waiting\") ~> (pc[t] = \"critical\")"
+  ]
+}
+```
+
+**CRITICAL REQUIREMENTS**: 
+- **PROPERTY TYPE AWARENESS**: Check each invariant's type field - safety properties MUST be state predicates, liveness properties MUST be temporal formulas
+- **SAFETY PROPERTIES**: Use ONLY unprimed variables, NO temporal operators (`[]`, `<>`, `~>`)
+- **LIVENESS PROPERTIES**: MUST use temporal operators (`<>`, `~>`) to express "eventually" or "leads-to" relationships
+- **SEMANTIC PRESERVATION**: Each translated invariant MUST verify the same safety/liveness property as the original template
+- **CREATIVE ADAPTATION**: Do NOT simply omit invariants - find creative ways to express the same property using available specification elements
+- **COMPLETENESS**: Aim to translate ALL invariants by understanding their semantic intent, not just their syntactic form
+- Use ONLY variables, constants, and operators that exist in the provided specification
+- Use EXACTLY the invariant names from the templates (MutualExclusion, LockConsistency, DeadlockFreedom, ThreadOwnership, GuardLifecycle, EventualAcquisition)
+- Return ONLY valid JSON, no explanatory text before or after
+- Each array element must be a complete TLA+ invariant definition: "InvariantName == <expression>"
+- For complex invariants, you may use multiline format within the JSON string (use actual line breaks)
+- For simple invariants, single line format is preferred
+- **LAST RESORT**: Only omit an invariant if its core concept is fundamentally incompatible with the specification's design
+- **CRITICAL JSON ESCAPING RULES**: 
+  - TLA+ operators like `\A`, `\E`, `\in` contain ONE backslash in the final TLA+ code
+  - In JSON strings, use EXACTLY ONE backslash escape: write `"\\A"` to get `\A` in TLA+
+  - **DO NOT double-escape**: `"\\\\A"` is WRONG and will produce `\\A` in TLA+
+  - **CORRECT**: `"MutualExclusion == \\A t \\in Threads : pc[t] = \"critical\""`
+  - **WRONG**: `"MutualExclusion == \\\\A t \\\\in Threads : pc[t] = \"critical\""`
+- Start your response immediately with the opening brace {

--- a/tla_eval/tasks/locksvc/prompts/trace_config_generation.txt
+++ b/tla_eval/tasks/locksvc/prompts/trace_config_generation.txt
@@ -1,0 +1,97 @@
+Generate a YAML configuration file from the provided TLA+ specification (.tla) and configuration (.cfg) files. Extract information according to the following rules:
+
+## Task Description
+Parse the TLA+ specification and configuration files to create a structured YAML configuration that captures the specification name, constants, variables, actions, and interactions.
+
+## Extraction Rules
+
+### spec_name
+Extract from the module declaration line: `---- MODULE <ModuleName> ----`
+The spec_name is the ModuleName between "---- MODULE" and "----".
+
+### constants
+Extract from the CONSTANTS section in the .cfg file.
+- name: The constant identifier
+- value: The assigned value, formatted as:
+  - Sets: Wrap in single quotes, e.g., '{s1, s2, s3}' becomes '{"s1", "s2", "s3"}'
+  - Strings: Wrap in single quotes with double quotes inside, e.g., Nil becomes '"Nil"'
+  - Numbers: Wrap in single quotes as string, e.g., 5 becomes '5'
+
+### variables
+Extract from the Init operator definition in the .tla file.
+For each variable assignment in Init:
+- name: The variable name
+- default_value: The initial value expression (preserve TLA+ syntax, escape backslashes)
+
+### actions
+Extract from the Next operator definition. Include only direct action calls (not numbered interactions).
+For each action:
+- name: The action/operator name
+- parameters: List of parameters with:
+  - name: Parameter variable name
+  - source: Where the parameter comes from (e.g., Server, messages)
+- stmt: The complete statement as it appears in Next (including any conditions)
+
+### interactions
+Extract from the Next operator definition. Include only numbered intermediate actions.
+Just list the names (e.g., HandletickElection_1, HandletickHeartbeat_1)
+
+## Example
+Given this TLA+ specification:
+
+---- MODULE SimpleSpec ----
+...
+Init ==
+/\ x = 0
+/\ y = [s \in Server |-> 0]
+
+Next ==
+\/ \E s \in Server : Action1(s)
+\/ \E m \in messages : Action2(m)
+\/ IntermediateAction_1
+
+And this configuration:
+
+CONSTANTS
+Server = {s1, s2}
+MaxValue = 10
+
+Generate this YAML:
+
+```yaml
+spec_name: SimpleSpec
+constants:
+- name: Server
+  value: '{"s1", "s2"}'
+- name: MaxValue
+  value: '10'
+variables:
+- name: x
+  default_value: '0'
+- name: y
+  default_value: '[s \\in Server |-> 0]'
+actions:
+- name: Action1
+  parameters:
+  - name: s
+    source: Server
+  stmt: Action1(s)
+- name: Action2
+  parameters:
+  - name: m
+    source: messages
+  stmt: Action2(m)
+interactions:
+- name: IntermediateAction_1
+```
+
+## Important Notes
+1. Return ONLY the YAML content - no explanations, comments, or natural language
+2. Preserve TLA+ syntax exactly in default_value fields (escape backslashes)
+3. For actions with conditions, include the full stmt as it appears in Next
+4. Ignore variables that appear in Init but are not part of the main specification (e.g., pc, info, stack)
+5. Order matters: spec_name, constants, variables, actions, interactions
+
+Generate the YAML configuration based on the provided TLA+ files:
+
+{source_code}

--- a/tla_eval/tasks/locksvc/task.yaml
+++ b/tla_eval/tasks/locksvc/task.yaml
@@ -1,0 +1,31 @@
+# Lock service task configuration
+name: "locksvc"
+description: "PGo-generated lock synchronization service"
+system_type: "distributed"
+language: "go"
+
+# Source code repository information
+repository:
+  url: "https://github.com/DistCompiler/pgo.git"
+  branch: "main"
+  
+# Files to extract from the repository
+source_files:
+  - path: "systems/locksvc/locksvc.go"
+    description: "Lock implementation"
+
+# Default file to use if not specified
+default_source_file: "systems/locksvc/locksvc.go"
+
+# TLA+ specification module name
+specModule: "locksvc"
+
+# Metadata
+metadata:
+  original_project: "DistCompiler/pgo"
+  
+# Phase 3 specific configuration
+phase3:
+  trace_generation: false
+  patch_required: false
+  description: "Lock synchronization verification"

--- a/tla_eval/tasks/raftkvs/prompts/agent_based.txt
+++ b/tla_eval/tasks/raftkvs/prompts/agent_based.txt
@@ -1,0 +1,52 @@
+You are an expert TLA+ specification specialist with extensive experience in distributed systems modeling.
+
+I need you to fix errors in a TLA+ specification for an Raft-based KV store {system_type} system.
+
+## Original Task Description
+{description}
+
+## Current TLA+ Specification (with errors)
+```tla
+{current_specification}
+```
+
+## Validation Errors Found
+**Error Summary:**
+{error_summary}
+
+**Detailed Syntax Errors:**
+{syntax_errors}
+
+**Detailed Semantic Errors:**
+{semantic_errors}
+
+**Full Validation Output:**
+```
+{validation_output}
+```
+
+## Correction Instructions
+This is correction attempt {attempt_number} of {max_attempts}.
+
+Please provide a corrected TLA+ specification that fixes these errors. Your corrected specification should:
+
+1. **Fix all syntax errors**: Ensure proper TLA+ syntax, correct operator usage, and valid module structure
+2. **Resolve semantic errors**: Define missing variables, operators, and ensure logical consistency
+3. **Maintain original intent**: Keep the core distributed system logic and behavior from the source code
+4. **Follow TLA+ best practices**: Use appropriate data structures, actions, and invariants
+5. **Be complete and self-contained**: Include all necessary EXTENDS, CONSTANTS, VARIABLES, and operator definitions
+
+Focus specifically on:
+- Defining any missing variables or constants
+- Implementing missing operators or functions
+- Fixing syntax issues with operators, expressions, or module structure
+- Ensuring proper action definitions and state transitions
+- Maintaining consistency with Raft's distributed consensus behavior
+
+**CRITICAL OUTPUT REQUIREMENTS:**
+- Return ONLY pure TLA+ specification code
+- NO markdown code blocks (no ```tla or ```)  
+- NO explanations, comments, or text outside the specification
+- NO formatting markers of any kind
+- The MODULE name must be exactly "raftkvs"
+- Start directly with: ---- MODULE raftkvs ----

--- a/tla_eval/tasks/raftkvs/prompts/direct_call.txt
+++ b/tla_eval/tasks/raftkvs/prompts/direct_call.txt
@@ -1,0 +1,41 @@
+You are an expert in formal verification and TLA+ specifications with deep expertise in distributed systems, particularly Raft consensus.
+
+Convert the following Raft implementation source code to a comprehensive TLA+ specification.
+
+System: Raft distributed key-value store
+Focus: {focus}
+
+Source Code from {file_path}:
+```go
+{source_code}
+```
+
+Raft-specific modeling requirements:
+
+MANDATORY CORE ACTIONS (must include all):
+1. 【Message Types】LeaderTimeout (election timeout), RequestVoteRequest/RequestVoteResponse (voting), AppendEntriesRequest/AppendEntriesResponse (log replication), ClientGetRequest/Response and ClientPutRequest/Response (KV storage)
+2. 【Node States】Three states: StateFollower, StateCandidate, StateLeader
+3. 【Leader Election】Complete voting phases: Candidate → Leader transitions
+4. 【Log Operations】Log entry appending, consistency checks, commitment with majority quorum
+5. 【Heartbeat/Timeout】Election timeouts triggering campaigns, heartbeat prevention of elections
+
+REQUIRED BEHAVIORAL SCOPE:
+- State transition constraints: Follower → Candidate → Leader (strict transitions)
+- Message processing by state: only valid message types handled in each node state
+- Term advancement rules: nodes advance term when receiving messages with higher term
+- Voting restrictions: one vote per term, term must be current or newer
+- Heartbeat mechanism: leaders send heartbeats, followers reset election timeout on receipt
+- Log consistency checks: prevLogIndex/prevLogTerm validation in AppendEntriesRequest/Response processing
+- Majority-based leader election and log commitment
+- Basic network message delays and losses
+
+Generate a TLA+ specification that accurately models Raft's distributed behavior.
+
+CRITICAL OUTPUT REQUIREMENTS:
+1. The MODULE name must be exactly "raftkvs" (---- MODULE raftkvs ----)
+2. Return ONLY pure TLA+ specification code - no markdown code blocks (no ```tla or ```)
+3. Do not include any explanations, comments, or formatting markers
+4. Start your response directly with: ---- MODULE raftkvs ----
+5. End your response with the closing ====
+6. **DO NOT define invariants** (like MutualExclusion, Invariant, etc.) - focus on modeling the system behavior
+7. **MUST include EXTENDS statement**: The specification must extend at least these modules: TLC, Sequences, SequencesExt, Naturals, FiniteSets, Bags

--- a/tla_eval/tasks/raftkvs/prompts/phase2_config.txt
+++ b/tla_eval/tasks/raftkvs/prompts/phase2_config.txt
@@ -1,0 +1,28 @@
+You are a TLA+ expert. Generate a complete TLC configuration file (.cfg) for the Raft KV store specification that can be directly saved and used for model checking.
+
+## Input Specification:
+
+$tla_spec
+
+## Generated Invariants:
+
+$invariants
+
+## Requirements:
+
+1. **Analyze the specification** to identify the main specification name and all declared constants
+2. **Generate complete .cfg file content** with SPECIFICATION, CONSTANTS, and INVARIANT sections
+3. **Use small values for constants** to ensure efficient model checking (2-3 servers, small integers)
+4. **Include ALL provided invariants** in the INVARIANT section
+5. **Output ONLY the raw .cfg file content** - no explanations, no markdown, no code blocks
+
+## Example Output Format:
+
+SPECIFICATION SpecName
+
+CONSTANTS
+    ...
+INVARIANT
+    ...
+
+**CRITICAL: Your response must contain exactly ONE complete .cfg file. Do not repeat any sections. Start your response immediately with "SPECIFICATION" and include nothing else. Each invariant name must be on its own line. Stop immediately after the last invariant name with no additional text.**

--- a/tla_eval/tasks/raftkvs/prompts/phase2_invariants.txt
+++ b/tla_eval/tasks/raftkvs/prompts/phase2_invariants.txt
@@ -1,0 +1,22 @@
+You are a TLA+ expert. Analyze the following Raft KV store TLA+ specification and generate meaningful invariants for model checking.
+
+## Input Specification:
+
+$tla_spec
+
+## Requirements:
+
+1. **Analyze the specification** to understand the Raft consensus behavior and state variables
+2. **Check existing invariants** - DO NOT generate invariants with names that already exist in the specification
+3. **Generate 2-3 NEW key invariants** that capture important safety properties for distributed consensus
+4. **Use proper TLA+ syntax** for each invariant definition (Name == Expression)
+5. **Focus on Raft consensus safety properties not already covered**
+6. **Output ONLY the raw invariant definitions** - no explanations, no markdown, no code blocks, no quotes
+
+## Expected Output Format:
+
+RaftSafety == condition1
+ConsistencyProperty == condition2
+LeaderUniqueness == condition3
+
+**IMPORTANT: Your response must contain only valid TLA+ invariant definitions that do NOT already exist in the specification. Start immediately with the first NEW invariant definition and include nothing else. Do not wrap in quotes or code blocks.**

--- a/tla_eval/tasks/raftkvs/prompts/phase3_invariant_implementation.txt
+++ b/tla_eval/tasks/raftkvs/prompts/phase3_invariant_implementation.txt
@@ -1,0 +1,83 @@
+You are a TLA+ expert specializing in distributed systems and Raft consensus. Your task is to implement a set of expert-written invariants for the given Raft KV store TLA+ specification.
+
+## Target Specification
+
+$tla_specification
+
+## Invariants to Implement
+
+$invariant_templates
+
+## Implementation Requirements
+
+1. **Deep Analysis**: First, thoroughly understand both the invariant template's semantic intent and the specification's modeling approach:
+   - What distributed consensus/safety property does each template aim to verify?
+   - How does the specification represent server states, logs, terms, and leadership?
+   - What are the semantic equivalents between template concepts and specification implementation?
+
+2. **Semantic Mapping**: For each invariant, identify the conceptual mapping between template and specification:
+   - Template server state concepts → Specification's server state representation
+   - Template log structure → Specification's log data structures and indexing
+   - Template leadership concepts → Specification's leader election and term management
+   - Template node/server sets → Specification's server constants and domains
+
+3. **Creative Adaptation**: Translate the invariant while preserving its core consensus safety meaning:
+   - **DO NOT** simply replace variable names - understand the underlying distributed systems logic
+   - **DO** redesign the predicate logic to fit the specification's data structure granularity
+   - **DO** use equivalent semantic concepts even if data representations differ
+   - **PRESERVE** the original Raft safety/liveness guarantees without weakening the property
+
+4. **TLA+ Property Type Constraints**:
+   
+   **FOR SAFETY PROPERTIES** (type: "safety"):
+   - **MUST** be STATE PREDICATES (describe single states only)
+   - **NEVER** use primed variables (`currentTerm'`, `log'`)
+   - **NEVER** use temporal operators (`[]`, `<>`, `~>`)
+   - **NEVER** reference actions (like `RequestVote(s)`, `AppendEntries(s,t)`) - only use state variables
+   - **ONLY** use unprimed variables (`currentTerm[s]`, `log[s]`) and constants
+   - **CORRECT**: `LeaderUniqueness == \A term \in Terms : Cardinality({s \in Servers : state[s] = "leader" /\ currentTerm[s] = term}) <= 1` 
+   - **INCORRECT**: `state[s] = "candidate" => RequestVote(s)`  (references action RequestVote)
+
+   **FOR LIVENESS PROPERTIES** (type: "liveness"): 
+   - **MUST** be TEMPORAL FORMULAS (describe execution traces)
+   - **MUST** use temporal operators (`<>`, `~>`) to express "eventually" or "leads-to"
+   - **CORRECT**: `EventualLeaderElection == <>(\E s \in Servers : state[s] = "leader")` 
+
+5. **Constraint Compliance**:
+   - Use ONLY variables, constants, and operators that exist in the specification
+   - Generate complete, syntactically valid TLA+ invariant definitions
+   - Maintain the exact invariant names from templates
+
+6. **Output format**: Return a JSON object containing an array of complete TLA+ invariant definitions
+
+7. **EXACT naming requirement**: You MUST use the exact invariant names specified in the templates above. Do not create your own names.
+
+## Example Output Format
+
+```json
+{
+  "invariants": [
+    "LeaderUniqueness == \\A term \\in 1..MaxTerm : Cardinality({n \\in Servers : state[n].role = \"leader\" /\\ state[n].currentTerm = term}) <= 1",
+    "LogConsistency == \\A n1, n2 \\in Servers : \\A i \\in DOMAIN log[n1] : (i \\in DOMAIN log[n2] /\\ log[n1][i].term = log[n2][i].term) => (\\A j \\in 1..i : log[n1][j] = log[n2][j])"
+  ]
+}
+```
+
+**CRITICAL REQUIREMENTS**: 
+- **SEMANTIC PRESERVATION**: Each translated invariant MUST verify the same distributed consensus property as the original template
+- **CREATIVE ADAPTATION**: Do NOT simply omit invariants - find creative ways to express the same property using available specification elements
+- **COMPLETENESS**: Aim to translate ALL invariants by understanding their semantic intent, not just their syntactic form
+- Use ONLY variables, constants, and operators that exist in the provided specification
+- Use EXACTLY the invariant names from the templates (preserve exact names for evaluation consistency)
+- Return ONLY valid JSON, no explanatory text before or after
+- Each array element must be a complete TLA+ invariant definition: "InvariantName == <expression>"
+- For complex invariants, you may use multiline format within the JSON string (use actual line breaks)
+- For simple invariants, single line format is preferred
+- **LAST RESORT**: Only omit an invariant if its core concept is fundamentally incompatible with the specification's design
+- **CRITICAL JSON ESCAPING RULES**: 
+  - TLA+ operators like `\A`, `\E`, `\in` contain ONE backslash in the final TLA+ code
+  - In JSON strings, use EXACTLY ONE backslash escape: write `"\\A"` to get `\A` in TLA+
+  - **DO NOT double-escape**: `"\\\\A"` is WRONG and will produce `\\A` in TLA+
+  - **CORRECT**: `"LeaderUniqueness == \\A term \\in 1..MaxTerm : state[term] = \"leader\""`
+  - **WRONG**: `"LeaderUniqueness == \\\\A term \\\\in 1..MaxTerm : state[term] = \"leader\""`
+- Start your response immediately with the opening brace {

--- a/tla_eval/tasks/raftkvs/prompts/trace_based.txt
+++ b/tla_eval/tasks/raftkvs/prompts/trace_based.txt
@@ -1,0 +1,42 @@
+You are an expert in formal verification and TLA+ specifications with deep expertise in distributed systems, particularly Raft consensus.
+
+Convert the following Raft implementation traces to a comprehensive TLA+ specification.
+
+System: Raft distributed key-value store
+Focus: {focus}
+
+Traces:
+{traces}
+
+Trace format interpretation:
+{trace_format}
+
+Raft-specific modeling requirements:
+
+MANDATORY CORE ACTIONS (must include all):
+1. 【Message Types】LeaderTimeout (election timeout), RequestVoteRequest/RequestVoteResponse (voting), AppendEntriesRequest/AppendEntriesResponse (log replication), ClientGetRequest/Response and ClientPutRequest/Response (KV storage)
+2. 【Node States】Three states: StateFollower, StateCandidate, StateLeader
+3. 【Leader Election】Complete voting phases: Candidate → Leader transitions
+4. 【Log Operations】Log entry appending, consistency checks, commitment with majority quorum
+5. 【Heartbeat/Timeout】Election timeouts triggering campaigns, heartbeat prevention of elections
+
+REQUIRED BEHAVIORAL SCOPE:
+- State transition constraints: Follower → Candidate → Leader (strict transitions)
+- Message processing by state: only valid message types handled in each node state
+- Term advancement rules: nodes advance term when receiving messages with higher term
+- Voting restrictions: one vote per term, term must be current or newer
+- Heartbeat mechanism: leaders send heartbeats, followers reset election timeout on receipt
+- Log consistency checks: prevLogIndex/prevLogTerm validation in AppendEntriesRequest/Response processing
+- Majority-based leader election and log commitment
+- Basic network message delays and losses
+
+Generate a TLA+ specification that accurately models Raft's distributed behavior.
+
+CRITICAL OUTPUT REQUIREMENTS:
+1. The MODULE name must be exactly "raftkvs" (---- MODULE raftkvs ----)
+2. Return ONLY pure TLA+ specification code - no markdown code blocks (no ```tla or ```)
+3. Do not include any explanations, comments, or formatting markers
+4. Start your response directly with: ---- MODULE raftkvs ----
+5. End your response with the closing ====
+6. **DO NOT define invariants** (like MutualExclusion, Invariant, etc.) - focus on modeling the system behavior
+7. **MUST include EXTENDS statement**: The specification must extend at least these modules: TLC, Sequences, SequencesExt, Naturals, FiniteSets, Bags

--- a/tla_eval/tasks/raftkvs/prompts/trace_config_generation.txt
+++ b/tla_eval/tasks/raftkvs/prompts/trace_config_generation.txt
@@ -1,0 +1,97 @@
+Generate a YAML configuration file from the provided TLA+ specification (.tla) and configuration (.cfg) files. Extract information according to the following rules:
+
+## Task Description
+Parse the TLA+ specification and configuration files to create a structured YAML configuration that captures the specification name, constants, variables, actions, and interactions.
+
+## Extraction Rules
+
+### spec_name
+Extract from the module declaration line: `---- MODULE <ModuleName> ----`
+The spec_name is the ModuleName between "---- MODULE" and "----".
+
+### constants
+Extract from the CONSTANTS section in the .cfg file.
+- name: The constant identifier
+- value: The assigned value, formatted as:
+  - Sets: Wrap in single quotes, e.g., '{s1, s2, s3}' becomes '{"s1", "s2", "s3"}'
+  - Strings: Wrap in single quotes with double quotes inside, e.g., Nil becomes '"Nil"'
+  - Numbers: Wrap in single quotes as string, e.g., 5 becomes '5'
+
+### variables
+Extract from the Init operator definition in the .tla file.
+For each variable assignment in Init:
+- name: The variable name
+- default_value: The initial value expression (preserve TLA+ syntax, escape backslashes)
+
+### actions
+Extract from the Next operator definition. Include only direct action calls (not numbered interactions).
+For each action:
+- name: The action/operator name
+- parameters: List of parameters with:
+  - name: Parameter variable name
+  - source: Where the parameter comes from (e.g., Server, messages)
+- stmt: The complete statement as it appears in Next (including any conditions)
+
+### interactions
+Extract from the Next operator definition. Include only numbered intermediate actions.
+Just list the names (e.g., HandletickElection_1, HandletickHeartbeat_1)
+
+## Example
+Given this TLA+ specification:
+
+---- MODULE SimpleSpec ----
+...
+Init ==
+/\ x = 0
+/\ y = [s \in Server |-> 0]
+
+Next ==
+\/ \E s \in Server : Action1(s)
+\/ \E m \in messages : Action2(m)
+\/ IntermediateAction_1
+
+And this configuration:
+
+CONSTANTS
+Server = {s1, s2}
+MaxValue = 10
+
+Generate this YAML:
+
+```yaml
+spec_name: SimpleSpec
+constants:
+- name: Server
+  value: '{"s1", "s2"}'
+- name: MaxValue
+  value: '10'
+variables:
+- name: x
+  default_value: '0'
+- name: y
+  default_value: '[s \\in Server |-> 0]'
+actions:
+- name: Action1
+  parameters:
+  - name: s
+    source: Server
+  stmt: Action1(s)
+- name: Action2
+  parameters:
+  - name: m
+    source: messages
+  stmt: Action2(m)
+interactions:
+- name: IntermediateAction_1
+```
+
+## Important Notes
+1. Return ONLY the YAML content - no explanations, comments, or natural language
+2. Preserve TLA+ syntax exactly in default_value fields (escape backslashes)
+3. For actions with conditions, include the full stmt as it appears in Next
+4. Ignore variables that appear in Init but are not part of the main specification (e.g., pc, info, stack)
+5. Order matters: spec_name, constants, variables, actions, interactions
+
+Generate the YAML configuration based on the provided TLA+ files:
+
+{source_code}

--- a/tla_eval/tasks/raftkvs/task.yaml
+++ b/tla_eval/tasks/raftkvs/task.yaml
@@ -1,0 +1,31 @@
+# PGo Raft KV store task configuration
+name: "raftkvs"
+description: "PGo-generated KV store with Raft consensus"
+system_type: "distributed"
+language: "go"
+
+# Source code repository information
+repository:
+  url: "https://github.com/DistCompiler/pgo.git"
+  branch: "main"
+  
+# Files to extract from the repository
+source_files:
+  - path: "systems/raftkvs/raftkvs.go" 
+    description: "Main Raft consensus algorithm and KV store implementation"
+
+# Default file to use if not specified
+default_source_file: "systems/raftkvs/raftkvs.go"
+
+# TLA+ specification module name
+specModule: "raftkvs"
+
+# Metadata
+metadata:
+  original_project: "DistCompiler/pgo"
+
+# Phase 3 specific configuration
+phase3:
+  trace_generation: false 
+  patch_required: false
+  description: "PGo-generated Raft KV store will use TraceLink traces"


### PR DESCRIPTION
This PR adds the prompts and `task.yaml` files for the `raftkvs` and `locksvc` systems. I haven't extensively tested this and I expect it'll rely on #6 for the trace validation bit.

@fhackett — please take a look over the system descriptions in `direct_call.txt`.