### PR TITLE
Serialization and config path fixes

### DIFF
--- a/tla_eval/evaluation/composite/composite_evaluation.py
+++ b/tla_eval/evaluation/composite/composite_evaluation.py
@@ -438,13 +438,21 @@ class CompositeEvaluator(BaseEvaluator):
             composite_result.output_directory = output_dir
             
             # Prepare result data and metadata for saving
+            def _serialize_result(result_obj):
+                """Convert evaluation result objects into JSON-serializable data."""
+                if result_obj is None:
+                    return None
+                if hasattr(result_obj, 'to_dict'):
+                    return result_obj.to_dict()
+                return result_obj
+
             result_data = {
                 'overall_success': composite_result.overall_success,
                 'generation_time': composite_result.generation_time,
-                'action_decomposition': getattr(composite_result, 'action_decomposition_result', None),
-                'compilation_check': getattr(composite_result, 'compilation_check_result', None),
-                'runtime_check': getattr(composite_result, 'runtime_check_result', None),
-                'manual_invariant': getattr(composite_result, 'manual_invariant_result', None)
+                'action_decomposition': _serialize_result(getattr(composite_result, 'action_decomposition_result', None)),
+                'compilation_check': _serialize_result(getattr(composite_result, 'compilation_check_result', None)),
+                'runtime_check': _serialize_result(getattr(composite_result, 'runtime_check_result', None)),
+                'manual_invariant': _serialize_result(getattr(composite_result, 'manual_invariant_result', None))
             }
             
             metadata = {
@@ -1145,4 +1153,3 @@ def create_composite_evaluator(validation_timeout: int = 30,
         invariant_iterations=invariant_iterations,
         keep_temp_files=keep_temp_files
     )
-

--- a/tla_eval/evaluation/semantics/runtime_check.py
+++ b/tla_eval/evaluation/semantics/runtime_check.py
@@ -634,7 +634,9 @@ class RuntimeCheckEvaluator(BaseEvaluator):
                     output_config_path = output_dir / f"{module_name}.cfg"
                     with open(output_config_path, 'w', encoding='utf-8') as f:
                         f.write(config)
-                    
+
+                    # Ensure downstream TLC runner uses the copied config in the output directory
+                    config_file_path = output_config_path
                     result.config_file_path = str(output_config_path)
                     result.config_generation_time = 0.0
                     result.config_generation_successful = True


### PR DESCRIPTION
This PR fixes:
- TLC config path bug when reusing existing config. Otherwise, TLC will throw a file not found error.
    - This seemed to affect all of my `trace_based` runs for `dqueue`. I'm not sure how extensively this may affect the other methods/systems given there seems to be some successes there.
- `result.json` serialization issue where the objects were serialized as opaque classes.