### PR TITLE
Add curp phase3 logic(WIP)

### DIFF
--- a/data/patches/xline-instrumented.patch
+++ b/data/patches/xline-instrumented.patch
@@ -1,0 +1,1019 @@
+diff --git a/.cargo/config.toml b/.cargo/config.toml
+new file mode 100644
+index 00000000..53aa0bfe
+--- /dev/null
++++ b/.cargo/config.toml
+@@ -0,0 +1,4 @@
++# It is weird that even if code does not change when running consecutive `cargo run` with `RUSTFLAGS="--cfg madsim"`, the code would still be recompiled.
++# Every compilation takes minutes (rocksdb is the bottleneck), which is annoying, so we manually set the rustflags here. IT JUST WORKS!
++[build]
++rustflags = ["--cfg", "madsim"]
+diff --git a/.gitignore b/.gitignore
+index 546ca5e0..4551e0b2 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -28,3 +28,6 @@ coverage
+ .vscode
+ .idea
+ out/
++
++__pycache__/
++states/
+\ No newline at end of file
+diff --git a/Cargo.lock b/Cargo.lock
+index b1e55a72..3f5f8ed9 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -682,6 +682,7 @@ dependencies = [
+  "prost-build",
+  "rand",
+  "serde",
++ "serde_json",
+  "sha2",
+  "tempfile",
+  "test-macros",
+@@ -689,6 +690,7 @@ dependencies = [
+  "tokio-stream 0.1.12",
+  "tokio-util",
+  "tower 0.4.13",
++ "trace",
+  "tracing",
+  "tracing-subscriber",
+  "tracing-test",
+@@ -2676,8 +2678,10 @@ dependencies = [
+ name = "simulation"
+ version = "0.1.0"
+ dependencies = [
++ "anyhow",
+  "async-trait",
+  "bincode",
++ "clap",
+  "curp",
+  "curp-test-utils",
+  "engine",
+@@ -2689,7 +2693,10 @@ dependencies = [
+  "madsim-tonic-build",
+  "parking_lot",
+  "prost",
++ "rand",
++ "serde_json",
+  "tempfile",
++ "trace",
+  "tracing",
+  "utils",
+  "workspace-hack",
+@@ -3136,6 +3143,15 @@ version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+ 
++[[package]]
++name = "trace"
++version = "0.1.0"
++dependencies = [
++ "anyhow",
++ "serde",
++ "serde_json",
++]
++
+ [[package]]
+ name = "tracing"
+ version = "0.1.40"
+diff --git a/config.toml b/config.toml
+new file mode 100644
+index 00000000..28b1b5e7
+--- /dev/null
++++ b/config.toml
+@@ -0,0 +1,3 @@
++# to config the Madsim runtime.
++[net]
++packet_loss_rate = 0.1
+diff --git a/crates/curp-external-api/src/cmd.rs b/crates/curp-external-api/src/cmd.rs
+index 5b282b8b..17f1a35a 100644
+--- a/crates/curp-external-api/src/cmd.rs
++++ b/crates/curp-external-api/src/cmd.rs
+@@ -50,6 +50,11 @@ pub trait Command: pri::Serializable + ConflictCheck + PbCodec {
+     /// Returns `true` if the command is read-only
+     fn is_read_only(&self) -> bool;
+ 
++    /// Used for trace validation.
++    fn trace_string(&self) -> String {
++        unimplemented!()
++    }
++
+     /// Execute the command according to the executor
+     ///
+     /// # Errors
+diff --git a/crates/curp-test-utils/src/test_cmd.rs b/crates/curp-test-utils/src/test_cmd.rs
+index c3fa2389..6901dba3 100644
+--- a/crates/curp-test-utils/src/test_cmd.rs
++++ b/crates/curp-test-utils/src/test_cmd.rs
+@@ -200,6 +200,10 @@ impl Command for TestCommand {
+             TestCommandType::Put(_) => false,
+         }
+     }
++
++    fn trace_string(&self) -> String {
++        unreachable!() // This line should never be reeached in simulation mode.
++    }
+ }
+ 
+ impl ConflictCheck for TestCommand {
+diff --git a/crates/curp/Cargo.toml b/crates/curp/Cargo.toml
+index 8645d6fa..2d3d21a9 100644
+--- a/crates/curp/Cargo.toml
++++ b/crates/curp/Cargo.toml
+@@ -35,6 +35,7 @@ priority-queue = "2.0.2"
+ prost = "0.13"
+ rand = "0.8.5"
+ serde = { version = "1.0.204", features = ["derive", "rc"] }
++serde_json = "1.0"
+ sha2 = "0.10.8"
+ thiserror = "1.0.61"
+ tokio = { version = "0.2.25", package = "madsim-tokio", features = [
+@@ -46,6 +47,7 @@ tokio-stream = { git = "https://github.com/madsim-rs/tokio.git", rev = "ab251ad"
+ tokio-util = "0.7.11"
+ tonic = { version = "0.5.0", package = "madsim-tonic", features = ["tls"] }
+ tower = { version = "0.4.13", features = ["filter"] }
++trace = { path = "../trace" }
+ tracing = { version = "0.1.37", features = ["std", "log", "attributes"] }
+ utils = { path = "../utils", version = "0.1.0", features = ["parking_lot"] }
+ workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+diff --git a/crates/curp/src/client/unary/propose_impl.rs b/crates/curp/src/client/unary/propose_impl.rs
+index d70033d9..d1a9dfaf 100644
+--- a/crates/curp/src/client/unary/propose_impl.rs
++++ b/crates/curp/src/client/unary/propose_impl.rs
+@@ -132,6 +132,15 @@ impl<C: Command> Unary<C> {
+             .send_leader_propose(cmd, leader_id, propose_id, use_fast_path, token)
+             .await?;
+         let follower_stream = self.send_record(cmd, leader_id, propose_id).await;
++
++        // trace Propose event.
++        #[cfg(madsim)]
++        {
++            use serde_json::json;
++            use trace::trace_event;
++            trace_event("Propose", json!({}));
++        }
++
+         let select = stream::select(Box::into_pin(leader_stream), Box::into_pin(follower_stream));
+ 
+         Ok(Box::new(select))
+diff --git a/crates/curp/src/members.rs b/crates/curp/src/members.rs
+index 5682268f..71e3a7e6 100644
+--- a/crates/curp/src/members.rs
++++ b/crates/curp/src/members.rs
+@@ -296,6 +296,20 @@ impl ClusterInfo {
+         cluster_name: &str,
+         timestamp: Option<u64>,
+     ) -> ServerId {
++        #[cfg(madsim)]
++        {
++            // Note: in simulation run, we use the IP address last octet as the server ID since it is deterministic.
++            // e.g.,192.168.1.1:2380 -> 1, 192.168.1.2:2380 -> 2, etc.
++            if let Some(addr) = addrs.first() {
++                if let Some(ip_part) = addr.split(':').next() {
++                    if let Some(last_octet) = ip_part.split('.').last() {
++                        if let Ok(id) = last_octet.parse::<u64>() {
++                            return id;
++                        }
++                    }
++                }
++            }
++        }
+         let mut hasher = DefaultHasher::new();
+         // to make sure same addrs but different order will get same id
+         addrs.sort();
+diff --git a/crates/curp/src/server/cmd_worker/mod.rs b/crates/curp/src/server/cmd_worker/mod.rs
+index 7ac5307b..91be7dc0 100644
+--- a/crates/curp/src/server/cmd_worker/mod.rs
++++ b/crates/curp/src/server/cmd_worker/mod.rs
+@@ -33,6 +33,42 @@ where
+             sp.remove(&pool_entry);
+             ucp.remove(&pool_entry);
+         };
++        // trace ProcessCommitMsg event.
++        #[cfg(madsim)]
++        {
++            use serde_json::json;
++            use trace::trace_event;
++            if let EntryData::Command(ref _cmd) = entry.entry_data {
++                let spec_pool = sp
++                    .all()
++                    .into_iter()
++                    .map(|entry| {
++                        json!({
++                            "id": entry.id.to_string(),
++                            "key": entry.cmd.trace_string(),
++                        })
++                    })
++                    .collect::<Vec<_>>();
++                let uncommitted_pool = ucp
++                    .all()
++                    .into_iter()
++                    .map(|entry| {
++                        json!({
++                            "id": entry.id.to_string(),
++                            "key": entry.cmd.trace_string(),
++                        })
++                    })
++                    .collect::<Vec<_>>();
++                trace_event(
++                    "ProcessCommitMsg",
++                    json!({
++                        "node_id": format!("r{}", curp.id()),
++                        "spec_pool": spec_pool,
++                        "uncommitted_pool": uncommitted_pool,
++                    }),
++                );
++            }
++        }
+     }
+ }
+ 
+diff --git a/crates/curp/src/server/conflict/uncommitted_pool.rs b/crates/curp/src/server/conflict/uncommitted_pool.rs
+index 432d72a1..f441f0a8 100644
+--- a/crates/curp/src/server/conflict/uncommitted_pool.rs
++++ b/crates/curp/src/server/conflict/uncommitted_pool.rs
+@@ -43,7 +43,7 @@ impl<C> UncommittedPool<C> {
+             .collect()
+     }
+ 
+-    #[cfg(test)]
++    #[allow(dead_code)]
+     /// Gets all entries in the pool
+     pub(crate) fn all(&self) -> Vec<PoolEntry<C>> {
+         let mut entries = Vec::new();
+diff --git a/crates/curp/src/server/curp_node.rs b/crates/curp/src/server/curp_node.rs
+index 95a4d15f..d4d5c431 100644
+--- a/crates/curp/src/server/curp_node.rs
++++ b/crates/curp/src/server/curp_node.rs
+@@ -288,6 +288,7 @@ impl<C: Command, CE: CommandExecutor<C>, RC: RoleChange> CurpNode<C, CE, RC> {
+     ) where
+         Executor: Fn(ExecutorEntry<C>),
+     {
++        // todo: maybe we should ban batch send?
+         if proposes.is_empty() {
+             return;
+         }
+diff --git a/crates/curp/src/server/raw_curp/log.rs b/crates/curp/src/server/raw_curp/log.rs
+index 472b1d90..23db0181 100644
+--- a/crates/curp/src/server/raw_curp/log.rs
++++ b/crates/curp/src/server/raw_curp/log.rs
+@@ -561,6 +561,21 @@ impl<C: Command> Log<C> {
+             commit_index,
+             self.commit_index
+         );
++
++        // trace Commit event.
++        #[cfg(madsim)]
++        {
++            use serde_json::json;
++            use trace::trace_event;
++            for i in (self.commit_index + 1)..=commit_index {
++                if let Some(entry) = self.get(i) {
++                    if let crate::log_entry::EntryData::Command(ref _cmd) = entry.entry_data {
++                        trace_event("Commit", json!({}));
++                    }
++                }
++            }
++        }
++
+         self.commit_index = commit_index;
+         self.fallback_contexts.retain(|&idx, c| {
+             if idx > self.commit_index {
+diff --git a/crates/curp/src/server/raw_curp/mod.rs b/crates/curp/src/server/raw_curp/mod.rs
+index b6f529c1..4ef8c247 100644
+--- a/crates/curp/src/server/raw_curp/mod.rs
++++ b/crates/curp/src/server/raw_curp/mod.rs
+@@ -513,6 +513,43 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
+             .lock()
+             .insert(PoolEntry::new(propose_id, Arc::clone(cmd)))
+             .is_some();
++
++        // trace ProcessProposeNonLeader event.
++        #[cfg(madsim)]
++        {
++            use serde_json::json;
++            use trace::trace_event;
++            let spec_entries = self.ctx.spec_pool.lock().all();
++            let spec_pool = spec_entries
++                .into_iter()
++                .map(|entry| {
++                    json!({
++                        "id": entry.id.to_string(),
++                        "key": entry.cmd.trace_string(),
++                    })
++                })
++                .collect::<Vec<_>>();
++            trace_event(
++                "ProcessProposeNonLeader",
++                json!({
++                    "node_id": format!("r{}", self.id()),
++                    "spec_pool": spec_pool,
++                    "uncommitted_pool": self
++                        .ctx
++                        .uncommitted_pool
++                        .lock()
++                        .all()
++                        .into_iter()
++                        .map(|entry| {
++                            json!({
++                                "id": entry.id.to_string(),
++                                "key": entry.cmd.trace_string(),
++                            })
++                        })
++                        .collect::<Vec<_>>(),
++                }),
++            );
++        }
+         if conflict {
+             metrics::get()
+                 .proposals_failed
+@@ -529,6 +566,42 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
+         for entry in entries {
+             let mut conflict = sp_l.insert(entry.clone()).is_some();
+             conflict |= ucp_l.insert(&entry);
++
++            // trace ProcessProposeLeader event.
++            #[cfg(madsim)]
++            {
++                use serde_json::json;
++                use trace::trace_event;
++                let spec_entries = sp_l.all();
++                let spec_pool = spec_entries
++                    .into_iter()
++                    .map(|entry| {
++                        json!({
++                            "id": entry.id.to_string(),
++                            "key": entry.cmd.trace_string(),
++                        })
++                    })
++                    .collect::<Vec<_>>();
++                let uncommitted_pool = ucp_l
++                    .all()
++                    .into_iter()
++                    .map(|entry| {
++                        json!({
++                            "id": entry.id.to_string(),
++                            "key": entry.cmd.trace_string(),
++                        })
++                    })
++                    .collect::<Vec<_>>();
++                trace_event(
++                    "ProcessProposeLeader",
++                    json!({
++                        "node_id": format!("r{}", self.id()),
++                        "spec_pool": spec_pool,
++                        "uncommitted_pool": uncommitted_pool,
++                    }),
++                );
++            }
++
+             conflicts.push(conflict);
+         }
+         metrics::get().proposals_failed.add(
+@@ -1742,6 +1815,48 @@ impl<C: Command, RC: RoleChange> RawCurp<C, RC> {
+         let _ignore = self.ctx.leader_event.notify(usize::MAX);
+         self.ctx.role_change.on_election_win();
+         debug!("{} becomes the leader", self.id());
++
++        // trace LeaderChange event.
++        #[cfg(madsim)]
++        {
++            use serde_json::json;
++            use trace::trace_event;
++            let spec_pool = self
++                .ctx
++                .spec_pool
++                .lock()
++                .all()
++                .into_iter()
++                .map(|entry| {
++                    json!({
++                        "id": entry.id.to_string(),
++                        "key": entry.cmd.trace_string(),
++                    })
++                })
++                .collect::<Vec<_>>();
++            let uncommitted_pool = self
++                .ctx
++                .uncommitted_pool
++                .lock()
++                .all()
++                .into_iter()
++                .map(|entry| {
++                    json!({
++                        "id": entry.id.to_string(),
++                        "key": entry.cmd.trace_string(),
++                    })
++                })
++                .collect::<Vec<_>>();
++            trace_event(
++                "LeaderChange",
++                json!({
++                    "node_id": format!("r{}", self.id()),
++                    "term": st.term,
++                    "spec_pool": spec_pool,
++                    "uncommitted_pool": uncommitted_pool,
++                }),
++            );
++        }
+     }
+ 
+     /// Server update self to a new term, will become a follower
+diff --git a/crates/curp/tla+/curp.tla b/crates/curp/tla+/curp.tla
+index c25847c4..584475c2 100644
+--- a/crates/curp/tla+/curp.tla
++++ b/crates/curp/tla+/curp.tla
+@@ -260,4 +260,4 @@ Stability ==
+ 
+ THEOREM Spec => []TypeOK /\ <>Stability
+ 
+-======================================================================================
++======================================================================================
+\ No newline at end of file
+diff --git a/crates/simulation/Cargo.toml b/crates/simulation/Cargo.toml
+index bbc988f0..90c7152b 100644
+--- a/crates/simulation/Cargo.toml
++++ b/crates/simulation/Cargo.toml
+@@ -11,8 +11,10 @@ categories = ["Test"]
+ keywords = ["Test", "Deterministic Simulation"]
+ 
+ [dependencies]
++anyhow = "1.0"
+ async-trait = "0.1.81"
+ bincode = "1.3.3"
++clap = { version = "4.0", features = ["derive"] }
+ curp = { path = "../curp" }
+ curp-test-utils = { path = "../curp-test-utils" }
+ engine = { path = "../engine" }
+@@ -21,7 +23,10 @@ itertools = "0.13"
+ madsim = "0.2.27"
+ parking_lot = "0.12.3"
+ prost = "0.13"
++rand = { version = "0.8", features = ["std_rng"] }
++serde_json = "1.0"
+ tempfile = "3"
++trace = { path = "../trace" }
+ tokio = { version = "0.2.25", package = "madsim-tokio", features = [
+     "rt",
+     "rt-multi-thread",
+@@ -39,5 +44,9 @@ xline = { path = "../xline" }
+ xline-client = { path = "../xline-client" }
+ xlineapi = { path = "../xlineapi" }
+ 
++[[bin]]
++name = "trace_generator"
++path = "src/bin/trace_generator.rs"
++
+ [build-dependencies]
+ tonic-build = { version = "0.5.0", package = "madsim-tonic-build" }
+diff --git a/crates/simulation/src/bin/trace_generator.rs b/crates/simulation/src/bin/trace_generator.rs
+new file mode 100644
+index 00000000..a84d9b08
+--- /dev/null
++++ b/crates/simulation/src/bin/trace_generator.rs
+@@ -0,0 +1,114 @@
++//! CURP trace generator.
++//! change to the root directory of Xline and run:
++//! MADSIM_TEST_CONFIG=./config.toml cargo run --bin trace_generator -- --nodes 3 --op-count 100 --trace-file trace.ndjson
++//! Normally we should add `RUSTFLAGS="--cfg madsim"` to the above command, but we manually set it in .cargo/config.toml, to avoid weird recompilation issues.
++//! There is a timing issue concerning logging. How can we make sure the first happend event gets logged first?
++//! However we don't have to consider this in Xline simulation mode backed by Madsim, since all nodes run in the same system thread.
++
++#![cfg(madsim)]
++
++use anyhow::Result;
++use clap::Parser;
++use madsim::rand::{self as madsim_rand, Rng};
++use madsim::time::Duration;
++use simulation::xline_group::XlineGroup;
++use std::collections::HashMap;
++use trace::init_global_trace_logger;
++use tracing::{error, info};
++
++#[derive(Parser)]
++#[command(name = "CURP trace generator")]
++#[command(about = "CURP trace generator")]
++struct Args {
++    #[arg(long, default_value = "3", help = "Cluster size")]
++    nodes: usize,
++
++    #[arg(long, default_value = "100", help = "Number of operations")]
++    op_count: usize,
++
++    #[arg(
++        long,
++        default_value = "trace.ndjson",
++        help = "Trace file path for cluster state"
++    )]
++    trace_file: String,
++}
++
++async fn run_test(args: Args) -> Result<()> {
++    // Failure injection (network packet loss) is controlled by the Madsim runtime.
++
++    // Use a HashMap as the oracle. But this is irrelevant to the trace generation.
++    let mut oracle = HashMap::<String, String>::new();
++
++    // Setup global trace logger.
++    init_global_trace_logger(&args.trace_file, args.nodes, false)?;
++    println!("Global trace logger setup complete.");
++
++    // Setup cluster.
++    let group = XlineGroup::new(args.nodes).await;
++    let client = group.client().await;
++
++    madsim::time::sleep(Duration::from_secs(1)).await;
++
++    let mut rng = madsim_rand::thread_rng();
++    let put_ratio = 0.7; // 70% PUT, 30% GET.
++    let _conflict_rate = 0.0; // Must be 0.0 due to TLA+ specification constraint.
++
++    let mut put_count = 0;
++    let mut get_count = 0;
++
++    // Main test loop.
++    for _ in 0..args.op_count {
++        if rng.gen::<f32>() < put_ratio {
++            // PUT operation.
++            let key = if put_count > 0 && rng.gen::<f32>() < 0.5 {
++                format!("key_{}", rng.gen_range(0..put_count))
++            } else {
++                format!("key_{}", put_count)
++            };
++            let value = format!("value_{}", put_count);
++            client.put(key.as_str(), value.as_str(), None).await?;
++            oracle.insert(key.clone(), value.clone());
++            put_count += 1;
++            info!("PUT {} = {}", key, value);
++        } else if !oracle.is_empty() {
++            // GET operation. This will not construct a command in Xline.
++            let keys: Vec<_> = oracle.keys().collect();
++            let key = keys[rng.gen_range(0..keys.len())].clone();
++            let result = client.range(key.as_str(), None).await?; // Note: SimClient only supports put, range, compact, watch.
++            let actual = result
++                .kvs
++                .first()
++                .map(|kv| String::from_utf8_lossy(&kv.value).to_string());
++            let expected = oracle.get(&key);
++
++            // Validate with the oracle.
++            if actual.as_ref() != expected {
++                error!(
++                    "CONSISTENCY VIOLATION: key={}, expected={:?}, actual={:?}. But in trace generation module, we allow this error. You may investigate it.",
++                    key, expected, actual
++                );
++            }
++            get_count += 1;
++            info!("GET {} = {:?}", key, actual);
++        }
++
++        madsim::time::sleep(Duration::from_millis(madsim_rand::random::<u64>() % 1001)).await;
++    }
++
++    // Print some summary.
++    println!("\n=== CURP Trace Generation Results ===");
++    println!(
++        "Operations: {} PUT + {} GET = {}",
++        put_count,
++        get_count,
++        put_count + get_count
++    );
++    Ok(())
++}
++
++#[madsim::main]
++async fn main() -> Result<()> {
++    let args = Args::parse();
++    run_test(args).await
++}
+diff --git a/crates/simulation/src/xline_group.rs b/crates/simulation/src/xline_group.rs
+index d3a0c41a..d1dd179b 100644
+--- a/crates/simulation/src/xline_group.rs
++++ b/crates/simulation/src/xline_group.rs
+@@ -54,7 +54,7 @@ impl XlineGroup {
+                     vec!["0.0.0.0:2379".to_owned()],
+                     vec![format!("192.168.1.{}:2379", i + 1)],
+                     all.clone(),
+-                    i == 0,
++                    false, // The original value is 0, we should ban this.
+                     CurpConfig::default(),
+                     ClientConfig::default(),
+                     ServerTimeout::default(),
+diff --git a/crates/trace/Cargo.toml b/crates/trace/Cargo.toml
+new file mode 100644
+index 00000000..eac9db21
+--- /dev/null
++++ b/crates/trace/Cargo.toml
+@@ -0,0 +1,9 @@
++[package]
++name = "trace"
++version = "0.1.0"
++edition = "2021"
++
++[dependencies]
++anyhow = "1.0"
++serde = { version = "1.0", features = ["derive"] }
++serde_json = "1.0"
+\ No newline at end of file
+diff --git a/crates/trace/src/lib.rs b/crates/trace/src/lib.rs
+new file mode 100644
+index 00000000..f0280876
+--- /dev/null
++++ b/crates/trace/src/lib.rs
+@@ -0,0 +1,374 @@
++//! Global trace logging for CURP protocol trace validation.
++//! This module corresponds to the curp.tla generated by Gemini.
++//! The basic principle of trace validation in our benchmark is that the spec should not be changed.
++
++use serde::{Deserialize, Serialize};
++use serde_json::json;
++use std::collections::{BTreeMap, BTreeSet};
++use std::fs::File;
++use std::io::Write;
++use std::sync::{Arc, Mutex};
++
++#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
++pub struct Command {
++    pub id: String,
++    pub key: String,
++}
++
++/// Corresponds to VARIABLES defined in curp.tla generated by Gemini.
++/// Note: some VARIABLES in the TLA+ spec are not logged since there are no proper corresponding structures in the implementation.
++#[derive(Clone, Debug, Serialize, Deserialize)]
++pub struct ClusterState {
++    /// term \in Nat.
++    pub term: u64,
++
++    /// leader \in Replicas.
++    pub leader: String,
++
++    /// role \in [Replicas -> {"Leader", "Follower"}].
++    pub role: BTreeMap<String, String>,
++
++    /// spec_pool \in [Replicas -> SUBSET Commands].
++    pub spec_pool: BTreeMap<String, BTreeSet<Command>>,
++
++    /// uncommitted_pool \subseteq Commands.
++    pub uncommitted_pool: BTreeSet<Command>,
++}
++
++impl ClusterState {
++    pub fn new(replicas: Vec<String>) -> Self {
++        let mut role = BTreeMap::new();
++        for replica in replicas.clone() {
++            role.insert(replica.clone(), "Follower".to_string());
++        }
++        role.insert("r1".to_string(), "Leader".to_string());
++        let mut spec_pool = BTreeMap::new();
++        for replica in replicas {
++            spec_pool.insert(replica, BTreeSet::new());
++        }
++        Self {
++            term: 0,
++            leader: "r1".to_string(),
++            role,
++            spec_pool,
++            uncommitted_pool: BTreeSet::new(),
++        }
++    }
++}
++
++#[derive(Clone)]
++pub struct GlobalTraceLogger {
++    cluster_state: Arc<Mutex<ClusterState>>,
++    trace_file: Arc<Mutex<File>>,
++    _replicas: Vec<String>,
++    ignore_all_variables: bool,
++}
++
++impl GlobalTraceLogger {
++    pub fn new(
++        trace_file: &str,
++        replica_count: usize,
++        ignore_all_variables: bool,
++    ) -> anyhow::Result<Self> {
++        let trace_file = File::create(trace_file)?;
++        // r1, r2, r3, ... curp.cfg should be aligned with this naming.
++        let replicas: Vec<String> = (1..=replica_count).map(|i| format!("r{}", i)).collect();
++        let cluster_state = ClusterState::new(replicas.clone());
++        Ok(Self {
++            cluster_state: Arc::new(Mutex::new(cluster_state)),
++            trace_file: Arc::new(Mutex::new(trace_file)),
++            _replicas: replicas,
++            ignore_all_variables,
++        })
++    }
++
++    pub fn trace_event(&self, event: &str, event_args: serde_json::Value) -> anyhow::Result<()> {
++        // Lock to prevent race conditions. But I doubt if it is necessary, since the entire Madsim is single-threaded.
++        let mut state = self.cluster_state.lock().unwrap();
++        let mut _ignore = BTreeSet::new();
++        match event {
++            "Propose" => {
++                // Client propose a command.
++                self.handle_propose(&mut state, &event_args)?;
++            }
++            "ProcessProposeLeader" => {
++                // Leader process a command.
++                self.handle_process_propose_leader(&mut state, &event_args)?;
++            }
++            "ProcessProposeNonLeader" => {
++                // Non-leader process a command.
++                self.handle_process_propose_non_leader(&mut state, &event_args)?;
++            }
++            "Commit" => {
++                // Leader of the backend consensus protocol decides to commit a command.
++                self.handle_commit(&mut state, &event_args)?;
++                _ignore.insert("uncommitted_pool".to_string());
++            }
++            "ProcessCommitMsg" => {
++                // Replica of the backend consensus protocol increase its commit index.
++                self.handle_process_commit_msg(&mut state, &event_args)?;
++            }
++            "LeaderChange" => {
++                // Backend consensus protocol elects a new leader.
++                self.handle_leader_change(&mut state, &event_args)?;
++            }
++            _ => {
++                eprintln!("Unknown event: {}", event);
++                return Ok(()); // The lock is dropped here.
++            }
++        }
++        self.write_trace_json(&state, event, _ignore)?; // The lock is held inside this function.
++        Ok(()) // The lock is dropped here.
++    }
++
++    fn handle_propose(
++        &self,
++        _state: &mut ClusterState,
++        _event_args: &serde_json::Value,
++    ) -> anyhow::Result<()> {
++        // Nothing to change.
++        Ok(())
++    }
++
++    fn handle_process_propose_leader(
++        &self,
++        state: &mut ClusterState,
++        event_args: &serde_json::Value,
++    ) -> anyhow::Result<()> {
++        // Update two VARIABLES: spec_pool, uncommitted_pool.
++        let node_id = event_args
++            .get("node_id")
++            .and_then(|v| v.as_str())
++            .ok_or_else(|| anyhow::anyhow!("Missing 'node_id' in ProcessProposeLeader event"))?;
++
++        if let Some(spec_pool_value) = event_args.get("spec_pool") {
++            let pool = Self::parse_command_set(spec_pool_value)?;
++            state.spec_pool.insert(node_id.to_string(), pool);
++        } else {
++            anyhow::bail!("Missing 'spec_pool' in ProcessProposeLeader event");
++        }
++
++        if let Some(uncommitted_pool_value) = event_args.get("uncommitted_pool") {
++            let pool = Self::parse_command_set(uncommitted_pool_value)?;
++            state.uncommitted_pool = pool;
++        } else {
++            anyhow::bail!("Missing 'uncommitted_pool' in ProcessProposeLeader event");
++        }
++
++        Ok(())
++    }
++
++    fn handle_process_propose_non_leader(
++        &self,
++        state: &mut ClusterState,
++        event_args: &serde_json::Value,
++    ) -> anyhow::Result<()> {
++        // Update one VARIABLES: spec_pool.
++        let node_id = event_args
++            .get("node_id")
++            .and_then(|v| v.as_str())
++            .ok_or_else(|| anyhow::anyhow!("Missing 'node_id' in ProcessProposeNonLeader event"))?;
++
++        if let Some(spec_pool_value) = event_args.get("spec_pool") {
++            let pool = Self::parse_command_set(spec_pool_value)?;
++            state.spec_pool.insert(node_id.to_string(), pool);
++        } else {
++            anyhow::bail!("Missing 'spec_pool' in ProcessProposeNonLeader event");
++        }
++
++        Ok(())
++    }
++
++    fn handle_commit(
++        &self,
++        _state: &mut ClusterState,
++        _event_args: &serde_json::Value,
++    ) -> anyhow::Result<()> {
++        // We should log uncommitted_pool, but we can not access it from the corrsponding instrumentation site.
++        // For now we ignore it.
++        // But we could log it if we change the function signature in the instrumentation site to include it, if really needed.
++        // if let Some(uncommitted_pool_value) = event_args.get("uncommitted_pool") {
++        //     let pool = Self::parse_command_set(uncommitted_pool_value)?;
++        //     state.uncommitted_pool = pool;
++        // }
++
++        Ok(())
++    }
++
++    fn handle_process_commit_msg(
++        &self,
++        state: &mut ClusterState,
++        event_args: &serde_json::Value,
++    ) -> anyhow::Result<()> {
++        // Update one VARIABLES: spec_pool.
++        let node_id = event_args["node_id"]
++            .as_str()
++            .ok_or_else(|| anyhow::anyhow!("Missing 'node_id' in ProcessCommitMsg event"))?;
++
++        if let Some(spec_pool_value) = event_args.get("spec_pool") {
++            let pool = Self::parse_command_set(spec_pool_value)?;
++            state.spec_pool.insert(node_id.to_string(), pool);
++        } else {
++            anyhow::bail!("Missing 'spec_pool' in ProcessCommitMsg event");
++        }
++
++        Ok(())
++    }
++
++    fn handle_leader_change(
++        &self,
++        state: &mut ClusterState,
++        event_args: &serde_json::Value,
++    ) -> anyhow::Result<()> {
++        // Update five VARIABLES: term, leader, role, spec_pool, uncommitted_pool.
++        let node_id = event_args["node_id"]
++            .as_str()
++            .ok_or_else(|| anyhow::anyhow!("Missing 'node_id' in LeaderChange event"))?;
++
++        state
++            .role
++            .insert(state.leader.clone(), "Follower".to_string());
++        state.leader = node_id.to_string(); // r1, r2, r3, ...
++        state.role.insert(node_id.to_string(), "Leader".to_string());
++
++        let term = event_args["term"]
++            .as_u64()
++            .ok_or_else(|| anyhow::anyhow!("Missing 'term' in LeaderChange event"))?;
++        state.term = term;
++
++        if let Some(spec_pool_value) = event_args.get("spec_pool") {
++            let pool = Self::parse_command_set(spec_pool_value)?;
++            state.spec_pool.insert(node_id.to_string(), pool);
++        } else {
++            anyhow::bail!("Missing 'spec_pool' in LeaderChange event");
++        }
++
++        if let Some(uncommitted_pool_value) = event_args.get("uncommitted_pool") {
++            let pool = Self::parse_command_set(uncommitted_pool_value)?;
++            state.uncommitted_pool = pool;
++        } else {
++            anyhow::bail!("Missing 'uncommitted_pool' in LeaderChange event");
++        }
++
++        Ok(())
++    }
++
++    fn parse_command(value: &serde_json::Value) -> anyhow::Result<Command> {
++        let id = value
++            .get("id")
++            .and_then(|v| v.as_str())
++            .ok_or_else(|| anyhow::anyhow!("Missing 'id' in command"))?;
++        let key = value
++            .get("key")
++            .and_then(|v| v.as_str())
++            .ok_or_else(|| anyhow::anyhow!("Missing 'key' in command"))?;
++        Ok(Command {
++            id: id.to_string(),
++            key: key.to_string(),
++        })
++    }
++
++    fn parse_command_set(value: &serde_json::Value) -> anyhow::Result<BTreeSet<Command>> {
++        let arr = value
++            .as_array()
++            .ok_or_else(|| anyhow::anyhow!("command collection should be an array"))?;
++        let mut set = BTreeSet::new();
++        for item in arr {
++            set.insert(Self::parse_command(item)?);
++        }
++        Ok(set)
++    }
++
++    /// Write a JSON trace in the ndjson file.
++    fn write_trace_json(
++        &self,
++        state: &ClusterState,
++        event: &str,
++        ignore: BTreeSet<String>,
++    ) -> anyhow::Result<()> {
++        let mut spec_pool_json = BTreeMap::new();
++        for (replica, pool) in &state.spec_pool {
++            let pool_vec: Vec<Command> = pool.iter().cloned().collect();
++            spec_pool_json.insert(replica.clone(), pool_vec);
++        }
++
++        let mut trace_record = json!({
++            "event": event
++        });
++
++        if self.ignore_all_variables {
++            let mut file = self.trace_file.lock().unwrap();
++            writeln!(file, "{}", trace_record)?;
++            file.flush()?;
++            return Ok(());
++        }
++
++        if !ignore.contains("leader") {
++            trace_record["leader"] = json!([{
++                "op": "Update",
++                "path": [],
++                "args": [state.leader.clone()]
++            }]);
++        }
++
++        if !ignore.contains("spec_pool") {
++            trace_record["spec_pool"] = json!([{
++                "op": "Update",
++                "path": [],
++                "args": [spec_pool_json]
++            }]);
++        }
++
++        if !ignore.contains("uncommitted_pool") {
++            trace_record["uncommitted_pool"] = json!([{
++                "op": "Update",
++                "path": [],
++                "args": [state.uncommitted_pool.clone()]
++            }]);
++        }
++
++        if !ignore.contains("term") {
++            trace_record["term"] = json!([{
++                "op": "Update",
++                "path": [],
++                "args": [state.term]
++            }]);
++        }
++
++        if !ignore.contains("role") {
++            trace_record["role"] = json!([{
++                "op": "Update",
++                "path": [],
++                "args": [state.role.clone()]
++            }]);
++        }
++
++        let mut file = self.trace_file.lock().unwrap();
++        writeln!(file, "{}", trace_record)?;
++        file.flush()?;
++
++        Ok(())
++    }
++}
++
++static GLOBAL_TRACE_LOGGER: std::sync::OnceLock<GlobalTraceLogger> = std::sync::OnceLock::new();
++
++pub fn init_global_trace_logger(
++    trace_file: &str,
++    replica_count: usize,
++    ignore_all_variables: bool,
++) -> anyhow::Result<()> {
++    let logger = GlobalTraceLogger::new(trace_file, replica_count, ignore_all_variables)?;
++    GLOBAL_TRACE_LOGGER
++        .set(logger)
++        .map_err(|_| anyhow::anyhow!("Global trace logger already initialized"))?;
++    Ok(())
++}
++
++pub fn trace_event(event: &str, event_args: serde_json::Value) {
++    if let Some(logger) = GLOBAL_TRACE_LOGGER.get() {
++        if let Err(e) = logger.trace_event(event, event_args) {
++            eprintln!("Failed to trace event: {}", e);
++        }
++    }
++}
+diff --git a/crates/xlineapi/src/command.rs b/crates/xlineapi/src/command.rs
+index c34c92ba..0671aef7 100644
+--- a/crates/xlineapi/src/command.rs
++++ b/crates/xlineapi/src/command.rs
+@@ -548,6 +548,15 @@ impl CurpCommand for Command {
+     fn is_read_only(&self) -> bool {
+         self.request().is_read_only()
+     }
++
++    #[inline]
++    fn trace_string(&self) -> String {
++        // Use the first key as the trace string.
++        self.keys()
++            .first()
++            .map(|key_range| String::from_utf8_lossy(key_range.range_start()).to_string())
++            .expect("Unable to extract trace string from command!")
++    }
+ }
+ 
+ impl Command {

--- a/tla_eval/core/trace_generation/curp/module.py
+++ b/tla_eval/core/trace_generation/curp/module.py
@@ -1,0 +1,431 @@
+"""
+CURP system implementation for trace generation and conversion.
+
+This module implements the system-specific interfaces for CURP
+trace generation and format conversion.
+"""
+
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..base import TraceGenerator, TraceConverter, SystemModule
+from .trace_converter_impl import CurpTraceConverterImpl
+
+
+class CurpTraceGenerator(TraceGenerator):
+    """CURP-specific trace generator implementation using patched Xline."""
+
+    def __init__(self):
+        # Project root: .../SysMoBench (tla_eval is parents[3], project root is parents[4])
+        project_root = Path(__file__).resolve().parents[4]
+        self.output_base = project_root / "data" / "sys_traces" / "curp"
+
+    def generate_traces(self, config: Dict[str, Any], output_dir: Path, name_prefix: str = "trace") -> List[Dict[str, Any]]:
+        """
+        Generate multiple runtime traces using patched Xline.
+
+        Args:
+            config: Configuration for trace generation
+            output_dir: Directory where trace files should be saved
+            name_prefix: Prefix for trace file names
+
+        Returns:
+            List of dictionaries with generation results for each trace
+        """
+        try:
+            # Extract configuration parameters
+            num_traces = config.get('num_traces', 20)
+            nodes = config.get('nodes', 3)
+            op_count = config.get('op_count', 20)
+
+            print(
+                f"Generating CURP traces: {num_traces} traces, {nodes} nodes, {op_count} ops")
+
+            # Ensure output directory exists
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+            # Check if we have existing traces in the curp directory
+            existing_traces_dir = Path(self.output_base)
+            if existing_traces_dir.exists():
+                existing_traces = sorted(
+                    list(existing_traces_dir.glob("trace_*.ndjson")))
+
+                if len(existing_traces) >= num_traces:
+                    print(
+                        f"Using {num_traces} existing traces from {existing_traces_dir}")
+                    return self._use_existing_traces(existing_traces[:num_traces], output_dir, name_prefix)
+
+            # If we don't have enough existing traces, fall back to generation
+            print(f"Not enough existing traces found, generating new ones...")
+            return self._generate_new_traces(config, output_dir, name_prefix, num_traces, nodes, op_count)
+
+        except Exception as e:
+            return [{
+                "success": False,
+                "error": f"CURP trace generation failed: {str(e)}",
+                "trace_file": "",
+                "event_count": 0,
+                "duration": 0.0,
+                "metadata": {}
+            }]
+
+    def _use_existing_traces(self, existing_traces: List[Path], output_dir: Path, name_prefix: str) -> List[Dict[str, Any]]:
+        """Use existing traces from the curp directory."""
+        results = []
+
+        for i, existing_trace in enumerate(existing_traces):
+            # Create output path
+            output_path = output_dir / f"{name_prefix}_{i+1:02d}.ndjson"
+
+            try:
+                # Copy the existing trace to the output directory
+                shutil.copy2(existing_trace, output_path)
+
+                # Count events in the trace
+                event_count = 0
+                with open(output_path, 'r') as f:
+                    for line in f:
+                        line = line.strip()
+                        if line and line.startswith('{'):
+                            try:
+                                json.loads(line)
+                                event_count += 1
+                            except json.JSONDecodeError:
+                                pass
+
+                results.append({
+                    "success": True,
+                    "trace_file": str(output_path),
+                    "event_count": event_count,
+                    "duration": 0.1,  # Minimal time for copying
+                    # todo: what metadata should be added?
+                })
+
+                print(
+                    f"  Used existing trace {i+1}: {event_count} events from {existing_trace.parent.name}")
+
+            except Exception as e:
+                results.append({
+                    "success": False,
+                    "error": f"Failed to copy existing trace: {str(e)}",
+                    "trace_file": str(output_path),
+                    "event_count": 0,
+                    "duration": 0.0,
+                    "metadata": {"failed": True}
+                })
+                print(f"  Failed to copy trace {i+1}: {str(e)}")
+
+        return results
+
+    def _generate_new_traces(self, config: Dict[str, Any], output_dir: Path, name_prefix: str,
+                             num_traces: int, nodes: int, op_count: int) -> List[Dict[str, Any]]:
+        """Generate new traces using the Xline trace generator (cargo run)."""
+        results = []
+
+        # Locate Xline repository prepared by RepositoryManager
+        project_root = Path(__file__).resolve().parents[4]
+        repo_path = project_root / "data" / "repositories" / "curp"
+
+        if not repo_path.exists():
+            print(
+                f"Xline repository not found at {repo_path}; cannot generate new traces.")
+            return [{
+                "success": False,
+                "error": f"Xline repository not prepared at {repo_path}",
+                "trace_file": "",
+                "event_count": 0,
+                "duration": 0.0,
+                "metadata": {}
+            }] * num_traces
+
+        # Build the generator binary first
+        if not self._build_generator(repo_path):
+            return [{
+                "success": False,
+                "error": "Failed to build CURP trace generator (cargo build)",
+                "trace_file": "",
+                "event_count": 0,
+                "duration": 0.0,
+                "metadata": {}
+            }] * num_traces
+
+        # Generate traces one by one
+        for i in range(num_traces):
+            output_path = output_dir / f"{name_prefix}_{i+1:02d}.ndjson"
+
+            print(f"Generating trace {i+1}/{num_traces}...")
+            result = self._generate_single_trace(
+                repo_path, nodes, op_count, output_path, i)
+            results.append(result)
+
+            if result["success"]:
+                print(
+                    f"  Generated trace {i+1}: {result['event_count']} events")
+            else:
+                print(f"  Failed to generate trace {i+1}: {result['error']}")
+
+        return results
+
+    def _build_generator(self, repo_path: Path) -> bool:
+        """Build the CURP trace generator."""
+        try:
+            print(
+                f"Building CURP generator in {repo_path}, this may take a while...")
+            result = subprocess.run(
+                ["cargo", "build", "--release", "--bin", "trace_generator"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                timeout=300
+            )
+            if result.returncode == 0:
+                print("Generator built successfully")
+                return True
+            else:
+                print(
+                    f"Generator build failed: {result.stderr or result.stdout}")
+                return False
+        except Exception as e:
+            print(f"Failed to build generator: {str(e)}")
+            return False
+
+    def _generate_single_trace(self, repo_path: Path, nodes: int, op_count: int, output_path: Path, run_id: int) -> Dict[str, Any]:
+        """Generate a single trace using the trace_generator.rs in Xline repo."""
+        try:
+            start_time = time.time()
+
+            cmd = [
+                "cargo", "run", "--release", "--bin", "trace_generator", "--",
+                "--nodes", str(nodes),
+                "--op-count", str(op_count),
+                "--trace-file", str(output_path),
+            ]
+
+            result = subprocess.run(
+                cmd,
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                timeout=60
+            )
+
+            execution_time = time.time() - start_time
+
+            if result.returncode != 0:
+                return {
+                    "success": False,
+                    "error": f"Generator failed with exit code {result.returncode}: {result.stderr or result.stdout}",
+                    "trace_file": str(output_path),
+                    "event_count": 0,
+                    "duration": execution_time,
+                    "metadata": {"run_id": run_id, "failed": True}
+                }
+
+            # Count events
+            event_count = 0
+            with open(output_path, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and line.startswith('{'):
+                        try:
+                            json.loads(line)
+                            event_count += 1
+                        except json.JSONDecodeError:
+                            pass
+
+            return {
+                "success": True,
+                "trace_file": str(output_path),
+                "event_count": event_count,
+                "duration": execution_time,
+                # todo: what metadata should be added?
+            }
+
+        except subprocess.TimeoutExpired:
+            return {
+                "success": False,
+                "error": "Generator timed out after 60s",
+                "trace_file": str(output_path),
+                "event_count": 0,
+                "duration": 60,
+                # todo: what metadata should be added?
+            }
+
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"Generator execution failed: {str(e)}",
+                "trace_file": str(output_path),
+                "event_count": 0,
+                "duration": 0.0,
+                # todo: what metadata should be added?
+            }
+
+    def generate_trace(self, config: Dict[str, Any], output_path: Path) -> Dict[str, Any]:
+        """
+        Generate single runtime trace using the patched Xline generator.
+
+        Args:
+            config: Configuration for trace generation
+            output_path: Path where trace file should be saved
+
+        Returns:
+            Dictionary with generation result
+        """
+        # Use the multi-trace method with count=1
+        results = self.generate_traces(
+            config, output_path.parent, output_path.stem)
+
+        if results and len(results) > 0:
+            return results[0]
+        else:
+            return {
+                "success": False,
+                "error": "Failed to generate single trace",
+                "trace_file": str(output_path),
+                "event_count": 0,
+                "duration": 0.0,
+                "metadata": {}
+            }
+
+    def get_default_config(self) -> Dict[str, Any]:
+        """Get default configuration for CURP trace generation."""
+        return {
+            "nodes": 3,
+            "op_count": 20,
+            "num_traces": 20,
+            # todo: should we add more parameters?
+        }
+
+    def get_available_scenarios(self) -> Dict[str, Dict[str, Any]]:
+        """Get available predefined scenarios for CURP."""
+        return {
+            "replication_basic": {
+                "nodes": 3,
+                "op_count": 20,
+                "num_traces": 20,
+                "description": "Basic CURP replication"
+            },
+            "replication_extended": {
+                "nodes": 3,
+                "op_count": 50,
+                "num_traces": 20,
+                "description": "Extended CURP replication"
+            },
+            "quick_test": {
+                "nodes": 3,
+                "op_count": 10,
+                "num_traces": 5,
+                "description": "Quick test with minimal traces"
+            }
+        }
+
+
+class CurpTraceConverter(TraceConverter):
+    """CURP-specific trace converter implementation."""
+
+    def __init__(self, spec_path: str = None):
+        """Initialize converter with optional spec path for mapping files."""
+        self.spec_path = spec_path
+
+    def convert_trace(self, input_path: Path, output_path: Path, spec_path: Path = None) -> Dict[str, Any]:
+        """
+        Convert CURP system trace to TLA+ specification-compatible format.
+
+        Args:
+            input_path: Path to the raw CURP trace file
+            output_path: Path where converted trace should be saved
+            spec_path: Optional path to spec directory for mapping files
+
+        Returns:
+            Dictionary with conversion results
+        """
+        try:
+            print(f"Converting CURP trace from {input_path} to {output_path}")
+
+            # Use spec_path if provided, otherwise use instance spec_path
+            effective_spec_path = str(
+                spec_path) if spec_path else self.spec_path
+
+            # Initialize CURP trace converter with spec path
+            converter = CurpTraceConverterImpl(spec_path=effective_spec_path)
+
+            # Perform conversion
+            result = converter.convert_trace(
+                input_trace_path=str(input_path),
+                output_trace_path=str(output_path)
+            )
+
+            if result["success"]:
+                return {
+                    "success": True,
+                    "input_events": result["input_events"],
+                    "output_transitions": result["output_transitions"],
+                    "output_file": result["output_file"]
+                }
+            else:
+                return {
+                    "success": False,
+                    "error": result["error"]
+                }
+
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"CURP trace conversion failed: {str(e)}"
+            }
+
+    def generate_mapping(self, spec_file: Path, model_name: str = None, output_path: Path = None) -> Dict[str, Any]:
+        """
+        Generate mapping configuration using LLM.
+
+        Args:
+            spec_file: Path to TLA+ specification file
+            model_name: Model to use for generation
+            output_path: Where to save the mapping file
+
+        Returns:
+            Dictionary with generation results
+        """
+        return CurpTraceConverterImpl.generate_mapping_with_llm(
+            spec_file=str(spec_file),
+            model_name=model_name,
+            output_path=str(output_path) if output_path else None
+        )
+
+
+class CurpSystemModule(SystemModule):
+    """Complete CURP system implementation."""
+
+    def __init__(self, spec_path: str = None):
+        self._trace_generator = CurpTraceGenerator()
+        self._trace_converter = CurpTraceConverter(spec_path=spec_path)
+        self.spec_path = spec_path
+
+    def get_trace_generator(self) -> TraceGenerator:
+        """Get the CURP trace generator."""
+        return self._trace_generator
+
+    def get_trace_converter(self) -> TraceConverter:
+        """Get the CURP trace converter."""
+        return self._trace_converter
+
+    def get_system_name(self) -> str:
+        """Get the system name identifier."""
+        return "curp"
+
+
+def get_system() -> SystemModule:
+    """
+    Factory function to get the CURP system implementation.
+
+    This function is called by the system registry to load this system.
+
+    Returns:
+        CurpSystemModule instance
+    """
+    return CurpSystemModule()

--- a/tla_eval/core/trace_generation/curp/trace_converter_impl.py
+++ b/tla_eval/core/trace_generation/curp/trace_converter_impl.py
@@ -1,0 +1,328 @@
+"""
+CURP Trace Converter Implementation
+
+Internal implementation class for CURP trace conversion.
+Converts CURP traces to TLA+ specification format for validation.
+"""
+
+import json
+import os
+from typing import Dict, Any, List
+from collections import defaultdict
+
+
+class CurpTraceConverterImpl:
+    """
+    Internal implementation for CURP trace conversion.
+
+    This handles the conversion from raw CURP traces (NDJSON format)
+    to the format expected by TLA+ specifications for validation.
+    """
+
+    def __init__(self, mapping_file: str = None, spec_path: str = None):
+        """
+        Initialize trace converter with mapping configuration.
+
+        Args:
+            mapping_file: Path to JSON mapping file (if None, looks in spec_path or default location)
+            spec_path: Path to the spec directory (used to find mapping file)
+        """
+        if mapping_file is None:
+            # Look in data/convertor/curp first, fallback to spec directory or module directory
+            data_mapping = "data/convertor/curp/curp_mapping.json"
+            module_mapping = os.path.join(
+                os.path.dirname(__file__), "curp_mapping.json")
+
+            if os.path.exists(data_mapping):
+                mapping_file = data_mapping
+            elif spec_path:
+                spec_mapping = os.path.join(spec_path, "curp_mapping.json")
+                if os.path.exists(spec_mapping):
+                    mapping_file = spec_mapping
+                else:
+                    mapping_file = module_mapping  # fallback to module directory
+            else:
+                mapping_file = module_mapping
+
+        self.mapping_file = mapping_file
+        self.spec_path = spec_path
+        self.mapping = self._load_mapping()
+
+    def _load_mapping(self) -> Dict[str, Any]:
+        """Load mapping configuration from JSON file."""
+        try:
+            with open(self.mapping_file, 'r') as f:
+                return json.load(f)
+        except Exception as e:
+            print(f"Failed to load mapping file {self.mapping_file}: {e}")
+            return {}
+
+    def _extract_value_from_event(self, event: Dict[str, Any], path: List[str], default_value: Any = None) -> Any:
+        """Extract value from event using dot notation path."""
+        current = event
+        try:
+            for key in path:
+                if isinstance(current, dict) and key in current:
+                    current = current[key]
+                else:
+                    return default_value
+            return current
+        except:
+            return default_value
+
+    def _map_node_id(self, node_id: str) -> str:
+        """Map system node ID to TLA+ node name."""
+        node_mapping = self.mapping.get("node_mapping", {})
+        return node_mapping.get(str(node_id), f"n{node_id}")
+
+    def _map_event_name(self, event_name: str) -> str:
+        """Map system event name to TLA+ action name."""
+        events_mapping = self.mapping.get("events", {})
+        return events_mapping.get(event_name, events_mapping.get("default", "Step"))
+
+    def _map_variable_value(self, var_config: Dict[str, Any], raw_value: Any, node_id: str) -> Any:
+        """Map system variable value to TLA+ format."""
+        # Apply value mapping if configured
+        if "value_mapping" in var_config and raw_value is not None:
+            value_mapping = var_config["value_mapping"]
+            # Check for exact match first
+            if str(raw_value) in value_mapping:
+                return value_mapping[str(raw_value)]
+            # Check for wildcard match
+            if "*" in value_mapping:
+                return value_mapping["*"]
+
+        # Handle special cases
+        if raw_value is None:
+            return var_config.get("default_value", "Nil")
+
+        # Convert numeric strings to numbers where appropriate
+        if isinstance(raw_value, str) and raw_value.isdigit():
+            return int(raw_value)
+
+        return raw_value
+
+    def _build_initial_state(self) -> Dict[str, Dict[str, Any]]:
+        """Build initial state with default values."""
+        state = defaultdict(dict)
+
+        node_mapping = self.mapping.get("node_mapping", {})
+        variables_config = self.mapping.get("variables", {})
+
+        for node_id, node_name in node_mapping.items():
+            for var_name, var_config in variables_config.items():
+                state[var_name][node_name] = var_config.get("default_value")
+
+        return state
+
+    def _update_state_with_event(self, state: Dict[str, Dict[str, Any]], event: Dict[str, Any]) -> None:
+        """Update state incrementally with a single event."""
+        node_id = event.get("nid", "1")
+        node_name = self._map_node_id(node_id)
+
+        variables_config = self.mapping.get("variables", {})
+
+        # Update each variable based on the event
+        for var_name, var_config in variables_config.items():
+            system_path = var_config.get("system_path", [])
+            raw_value = self._extract_value_from_event(event, system_path)
+            if raw_value is not None:
+                mapped_value = self._map_variable_value(
+                    var_config, raw_value, node_id)
+                state[var_name][node_name] = mapped_value
+
+    def convert_trace(self, input_trace_path: str, output_trace_path: str, config: Dict[str, Any] = None) -> Dict[str, Any]:
+        """
+        Convert trace from CURP format to TLA+ spec format.
+
+        Args:
+            input_trace_path: Path to input trace file (NDJSON)
+            output_trace_path: Path for output trace file
+            config: Configuration for conversion
+
+        Returns:
+            Dictionary with conversion results
+        """
+        try:
+            # Ensure output directory exists
+            os.makedirs(os.path.dirname(output_trace_path), exist_ok=True)
+
+            # Read input trace
+            events = []
+            with open(input_trace_path, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and line.startswith('{'):
+                        try:
+                            event = json.loads(line)
+                            events.append(event)
+                        except json.JSONDecodeError as e:
+                            print(
+                                f"Skipping invalid JSON line: {line[:100]}... Error: {e}")
+                        continue
+
+            if not events:
+                return {"success": False, "error": "No valid events found in input trace"}
+
+            # Convert using state-based mapping
+            return self._convert_state_based(events, output_trace_path)
+
+        except Exception as e:
+            return {"success": False, "error": f"CURP trace conversion failed: {str(e)}"}
+
+    def _convert_state_based(self, events: List[Dict[str, Any]], output_trace_path: str) -> Dict[str, Any]:
+        """
+        Convert trace using state-based mapping.
+        """
+        output_lines = []
+
+        # First line: configuration
+        config_line = json.dumps(self.mapping.get("config", {}))
+        output_lines.append(config_line)
+
+        # Initialize state once
+        state = self._build_initial_state()
+
+        for event in events:
+            # Update state incrementally with current event
+            self._update_state_with_event(state, event)
+
+            # Map event name to TLA+ action
+            event_name = event.get("name", "Step")
+            tla_action = self._map_event_name(event_name)
+
+            # Build output line
+            output_event = {}
+
+            # Add all variables with their current state
+            for var_name, node_values in state.items():
+                output_event[var_name] = [{
+                    "op": "Update",
+                    "path": [],
+                    # Convert to dict for JSON serialization
+                    "args": [dict(node_values)]
+                }]
+
+            # Add event name
+            output_event["event"] = tla_action
+
+            output_lines.append(json.dumps(output_event))
+
+        # Write output trace
+        with open(output_trace_path, 'w') as f:
+            for line in output_lines:
+                f.write(line + '\n')
+
+        return {
+            "success": True,
+            "input_events": len(events),
+            "output_transitions": len(output_lines) - 1,  # Exclude config line
+            "output_file": output_trace_path,
+            "format": "state-based"
+        }
+
+    @classmethod
+    def generate_mapping_with_llm(cls, spec_file: str, model_name: str = None, output_path: str = None) -> Dict[str, Any]:
+        """
+        Generate a mapping configuration using LLM based on TLA+ specification.
+
+        Args:
+            spec_file: Path to TLA+ specification file
+            model_name: Name of the model to use for generation
+            output_path: Path to save the generated mapping (if None, saves next to spec)
+
+        Returns:
+            Dictionary with generation results
+        """
+        try:
+            # Import LLM functionality
+            from ....config import get_configured_model
+
+            # Read the TLA+ spec
+            with open(spec_file, 'r') as f:
+                spec_content = f.read()
+
+            # Load prompt template from file
+            # Get the project root directory
+            current_file = os.path.abspath(__file__)
+            project_root = current_file
+            for _ in range(5):  # Go up 5 levels from trace_converter_impl.py
+                project_root = os.path.dirname(project_root)
+
+            prompt_file = os.path.join(
+                project_root, "tla_eval", "tasks", "curp", "prompts", "mapping_generation.txt"
+            )
+
+            if not os.path.exists(prompt_file):
+                raise FileNotFoundError(
+                    f"Prompt template not found: {prompt_file}")
+
+            with open(prompt_file, 'r', encoding='utf-8') as f:
+                prompt_template = f.read()
+
+            # Replace placeholders in the template
+            prompt = prompt_template.replace(
+                "{TLA_SPEC_CODE_PLACEHOLDER}", spec_content)
+            prompt = prompt.replace(
+                "{IMPLEMENTATION_CODE_PLACEHOLDER}", "# CURP implementation details")
+            prompt += "\n\nReturn ONLY valid JSON, no explanations or markdown."
+
+            # Get the configured model
+            model = get_configured_model(model_name)
+
+            # Generate the mapping
+            response = model.generate_tla_specification(
+                source_code="",
+                prompt_template=prompt
+            )
+
+            # Parse the JSON response
+            try:
+                # Clean up the response - remove markdown formatting if present
+                json_text = response.generated_text.strip()
+                if json_text.startswith('```'):
+                    # Remove markdown code blocks
+                    lines = json_text.split('\n')
+                    json_lines = []
+                    in_block = False
+                    for line in lines:
+                        if line.strip().startswith('```'):
+                            in_block = not in_block
+                        elif in_block or not line.strip().startswith('```'):
+                            if not line.strip().startswith('```'):
+                                json_lines.append(line)
+                    json_text = '\n'.join(json_lines)
+
+                mapping_data = json.loads(json_text)
+
+                # Validate the structure for state-based format
+                required_keys = ['config', 'events',
+                                 'variables', 'node_mapping']
+                for key in required_keys:
+                    if key not in mapping_data:
+                        raise ValueError(f"Missing required key: {key}")
+
+                # Save the mapping file
+                if output_path is None:
+                    spec_dir = os.path.dirname(spec_file)
+                    output_path = os.path.join(
+                        spec_dir, "curp_mapping.json")
+
+                with open(output_path, 'w') as f:
+                    json.dump(mapping_data, f, indent=2)
+
+                return {
+                    "success": True,
+                    "mapping_file": output_path,
+                    "mapping": mapping_data
+                }
+
+            except (json.JSONDecodeError, ValueError) as e:
+                return {
+                    "success": False,
+                    "error": f"Failed to parse LLM response as JSON: {str(e)}",
+                    "response": response.generated_text[:500]
+                }
+
+        except Exception as e:
+            return {"success": False, "error": f"Failed to generate CURP mapping: {str(e)}"}

--- a/tla_eval/tasks/curp/task.yaml
+++ b/tla_eval/tasks/curp/task.yaml
@@ -6,16 +6,24 @@ language: "rust"
 
 # Source code repository information
 repository:
-  url: "https://github.com/datenlord/curp.git"
-  branch: "main"
-  
+  url: "https://github.com/xline-kv/Xline.git"
+  branch: "master"
+  commit: "71479a4fabdd12fe67eec0bee95e652976937541"
+  have_submodule: true
+
 # Files to extract from the repository
 source_files:
-  - path: "curp.rs"
-    description: "Main CURP consensus protocol implementation with client and server logic"
+  - path: "crates/curp/src/server/raw_curp/mod.rs"
+    description: "Core server logic of CURP and Raft"
+  - path: "crates/curp/src/server/curp_node.rs"
+    description: "Core server logic of CURP"
+  - path: "crates/curp/src/client/unary/propose_impl.rs"
+    description: "Core client logic of CURP"
+  - path: "crates/curp/src/lib.rs"
+    description: "Quorum value definitions of CURP"
 
 # Default file to use if not specified
-default_source_file: "curp.rs"
+default_source_file: "crates/curp/src/server/raw_curp/mod.rs"
 
 # TLA+ specification module name
 specModule: "curp"
@@ -37,5 +45,6 @@ metadata:
 # Phase 3 specific configuration
 phase3:
   trace_generation: false
-  patch_required: false
-  description: "CURP consensus protocol with abstracted Raft for reduced complexity"
+  patch_required: true
+  patch_file: "data/patches/xline-instrumented.patch"
+  description: "CURP replication protocol with abstracted Raft for reduced complexity"


### PR DESCRIPTION
This PR makes the following changes:
- In `repository_manager.py`, added support for `git clone --recurse-submodules`
- Added `module.py` and `trace_converter_impl.py` for CURP
- Added git patch file for the instrumented Xline source code
- Modified `task.yaml` for CURP accordingly
- The "clone the repo -> build the repo -> run the repo to generate traces" logic in `module.py` has been tested. But the trace mapping logic hasn't

TODO:
- Test trace mapping logic in `module.py` and `trace_converter_impl.py`