### PR TITLE
invariant_verification: fix agent translator model code and errors

### DIFF
--- a/tla_eval/evaluation/semantics/manual_invariant_evaluator.py
+++ b/tla_eval/evaluation/semantics/manual_invariant_evaluator.py
@@ -501,8 +501,16 @@ Write a JSON file to `./output/invariants.json` with this exact format:
                 cmd.extend(["-m", model])
             cmd.append("Read CODEX.md and complete the invariant translation task.")
         else:
-            # Determine model to use for Claude Code
-            model = model_name if model_name and model_name != "default" else "sonnet"
+            # The `claude` CLI accepts model codes (sonnet/opus/haiku) or
+            # full model IDs — not SysMoBench aliases like "claude", which
+            # produce a "400 Unknown Model". Map anything else to "sonnet".
+            cli_model_codes = {"sonnet", "opus", "haiku"}
+            if model_name in cli_model_codes or (
+                model_name and model_name.startswith("claude-")
+            ):
+                model = model_name
+            else:
+                model = "sonnet"
             cmd = [
                 "claude",
                 "--print",
@@ -530,12 +538,18 @@ Write a JSON file to `./output/invariants.json` with this exact format:
                 await process.wait()
                 return {"success": False, "error": f"Timeout after {self.timeout} seconds"}
 
+            out = stdout.decode("utf-8", errors="replace")
+            err = stderr.decode("utf-8", errors="replace")
+
             return {
                 "success": process.returncode == 0,
-                "stdout": stdout.decode("utf-8", errors="replace"),
-                "stderr": stderr.decode("utf-8", errors="replace"),
+                "stdout": out,
+                "stderr": err,
                 "exit_code": process.returncode,
-                "error": stderr.decode("utf-8", errors="replace") if process.returncode != 0 else None,
+                # `claude --output-format json` writes its error payload to
+                # stdout and leaves stderr empty; fall back to stdout so the
+                # failure reason is not lost.
+                "error": (err or out) if process.returncode != 0 else None,
             }
 
         except FileNotFoundError:

--- a/tla_eval/evaluation/semantics/manual_invariant_evaluator.py
+++ b/tla_eval/evaluation/semantics/manual_invariant_evaluator.py
@@ -502,15 +502,25 @@ Write a JSON file to `./output/invariants.json` with this exact format:
             cmd.append("Read CODEX.md and complete the invariant translation task.")
         else:
             # The `claude` CLI accepts model codes (sonnet/opus/haiku) or
-            # full model IDs — not SysMoBench aliases like "claude", which
-            # produce a "400 Unknown Model". Map anything else to "sonnet".
+            # full model IDs (claude-*) — not SysMoBench aliases like
+            # "claude_opus_proxy", which would yield "400 Unknown Model".
+            # Refuse anything else so callers don't silently run against a
+            # different model than they configured.
             cli_model_codes = {"sonnet", "opus", "haiku"}
             if model_name in cli_model_codes or (
                 model_name and model_name.startswith("claude-")
             ):
                 model = model_name
             else:
-                model = "sonnet"
+                return {
+                    "success": False,
+                    "error": (
+                        f"Agent translator (claude CLI) needs a "
+                        f"sonnet/opus/haiku code or a claude-* model ID; "
+                        f"got {model_name!r}. Pass a valid code at the call "
+                        f"site instead of relying on a fallback."
+                    ),
+                }
             cmd = [
                 "claude",
                 "--print",


### PR DESCRIPTION
## Problem

`invariant_verification --inv-translator-type agent` fails silently — an
empty error string and an instant FAIL — for two independent reasons in
`AgentInvariantTranslator._execute_agent_cli`:

**1. Invalid model code.** The translator passes `model_name` straight to
`claude --model`:

```python
model = model_name if model_name and model_name != "default" else "sonnet"
cmd = ["claude", "--print", ..., "--model", model, ...]
```

`model_name` is a SysMoBench alias — e.g. the `claude` entry shipped in
`config/models.yaml`. But the `claude` CLI only accepts model *codes*
(`sonnet`/`opus`/`haiku`) or full model IDs. `--model claude` returns
`400 Unknown Model, please check the model code`, so every agent
translation fails in ~8s.

**2. Swallowed error.** On failure the result's `error` is taken from
stderr:

```python
"error": stderr.decode(...) if process.returncode != 0 else None
```

With `--output-format json` the `claude` CLI writes its error payload to
**stdout** and leaves stderr empty — so the caller sees an empty error
string and the real cause is invisible.

## Fix

1. Map unrecognised model names to `sonnet` (keep `sonnet`/`opus`/`haiku`
   and full `claude-*` IDs as-is).
2. Fall back to stdout when stderr is empty, so the failure reason is
   preserved.

Together these turn the silent FAIL into either a working translation or
a diagnosable error.