### PR TITLE
Add JS-SAM language backend (fourth spec language)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ docs/leaderboard/specs_repaired/
 # inside docs/leaderboard/. The top-level `states/` rule above handles the
 # common case; this one covers nested writes during repair/rescore runs.
 docs/leaderboard/**/states/
+
+# Node (JS-SAM helper)
+node_modules/

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -25,7 +25,9 @@ models:
     model_name: "claude-sonnet-4-20250514"
     api_key_env: "ANTHROPIC_API_KEY"
     temperature: 0.1
-    max_tokens: 200000
+    # claude-sonnet-4 rejects max_tokens > 64000 (API: "maximum allowed
+    # number of output tokens for claude-sonnet-4-20250514"); probed 2026-06-09.
+    max_tokens: 64000
     top_p: 0.9
 
   deepseek_tencent:

--- a/data/js_sam_invariant_templates/spin/invariants.yaml
+++ b/data/js_sam_invariant_templates/spin/invariants.yaml
@@ -1,0 +1,47 @@
+# JS-SAM Invariants for Asterinas Spinlock Systems
+#
+# First-cut starter set: three generic spinlock invariants reused from the
+# Alloy library (data/alloy_invariant_templates/spin/invariants.yaml).
+# The javascript_example snippets are written against the RECOMMENDED state
+# shape from the JS-SAM prompt; the translator adapts them to the state shape
+# the generated specification actually produces.
+#
+# Predicate convention: (state) => boolean, receiving the plain getState()
+# snapshot; true = invariant HOLDS, false = VIOLATED.
+
+invariants:
+  - name: "MutualExclusion"
+    type: "safety"
+    natural_language: "At most one thread can hold any lock at any given time"
+    formal_description: "The fundamental safety property: no two threads can hold the same lock simultaneously"
+    javascript_example: |
+      (state) => Object.values(state.threadStatus || {}).filter((s) => s === 'locked').length <= 1
+
+  - name: "LockStatusConsistency"
+    type: "safety"
+    natural_language: "If a thread holds a lock, it must be in Locked status"
+    formal_description: "Lock state consistency: the thread status must accurately reflect lock ownership"
+    javascript_example: |
+      (state) => state.lockHolder === null || state.lockHolder === undefined
+        || (state.threadStatus || {})[String(state.lockHolder)] === 'locked'
+
+  - name: "NoDeadlock"
+    type: "safety"
+    natural_language: "Not all threads can be in Trying state simultaneously - prevents global deadlock"
+    formal_description: "Deadlock freedom: prevents the situation where all threads are stuck trying to acquire locks simultaneously"
+    javascript_example: |
+      (state) => Object.values(state.threadStatus || {}).some((s) => s !== 'trying')
+
+metadata:
+  total_invariants: 3
+  safety_invariants: 3
+  liveness_invariants: 0
+  note: >
+    Liveness properties are not included: the sam-pattern behavior explorer
+    performs bounded exploration and cannot verify unbounded temporal
+    properties (same limitation as the Alloy and PAT libraries).
+  parity_note: >
+    Alloy ships 6 invariants for spin (4 generic + 2 Asterinas-specific:
+    TryLockNonBlocking, BlockingVsNonBlockingSemantics). Extending JS-SAM
+    from 3 to 6 is a follow-up item, not first-cut scope — see
+    docs/js_sam_backend_spec.md US-7.

--- a/docs/add_new_spec_language.md
+++ b/docs/add_new_spec_language.md
@@ -178,7 +178,7 @@ Codex) that knows how to read the spec, slice traces into
 language means extending the skill, which is a larger project than writing
 a backend. Plan accordingly.
 
-**Direct path.** If your language's model checker has a CLI that answers
+**Direct path.** If your language's tooling can answer
 "is `pre ∧ action ⇒ post'` valid?" directly without orchestration, set
 `supports_direct_transition_validation = True` and implement:
 
@@ -193,12 +193,20 @@ def validate_transitions(
 ```
 
 Populate `per_action_pass_rates`, `total_passed`, `total_windows`. The
-evaluator-side wrapper for this path is stubbed in
-`transition_validation.py` — you'll need to thread the trace loader through
-on the first language that uses it; flag it on the integration thread.
+contract split: the **evaluator** owns trace loading and windowing
+(language-neutral, `tla_eval/evaluation/semantics/trace_loader.py` — it
+resolves `task.yaml > traces_folder`, parses the NDJSON trace files, slices
+them into windows, and filters to `tv.target_actions`); the **backend** owns
+validating each window against the spec. Each window's `action` is either a
+plain action-name string or `{"name": ..., "data": ...}` when the trace
+record carries an argument payload. See the trace_loader module docstring
+for the two accepted NDJSON record shapes (self-contained event records vs
+consecutive state-stream records).
 
-Today neither TLA+, Alloy, nor PAT exposes a direct API, so all three
-inherit the agent path.
+TLA+, Alloy, and PAT expose no direct API, so all three inherit the agent
+path. JS-SAM is the direct path's reference implementation
+(`js_sam.py:validate_transitions` — SAM trace replay is
+`setState(pre); actions[name](data); diff(getState(), post)`).
 
 ### 3.4 Phase 4 — Invariant verification
 
@@ -305,8 +313,8 @@ Each entry:
 ```
 
 You only need to populate entries for the systems you intend to evaluate.
-TLA+ templates exist for all 11 systems; Alloy and PAT historically
-covered only `spin`.
+TLA+ templates exist for all 11 systems; Alloy, PAT, and JS-SAM cover
+only `spin`.
 
 ---
 
@@ -375,6 +383,7 @@ Phase 2 / Phase 4 follow the same pattern, swap `--metric`.
 | TLA+     | `tla_eval/languages/tla_plus.py`    | Wraps existing TLAValidator/TLCRunner/InvariantTranslator. |
 | Alloy    | `tla_eval/languages/alloy.py`       | Java helper (`AlloyCliValidator`, `AlloyRuntime`) over `lib/alloy.jar`. |
 | PAT      | `tla_eval/languages/pat.py`         | `mono lib/PAT3.Console.exe`; PAT always returns exit 0 so failures are text-detected. |
+| JS-SAM   | `tla_eval/languages/js_sam.py`      | Node helper (`tools/js-sam/cli.mjs`, JSON-in/JSON-out) over `@cognitive-fab/sam-pattern`. First (and reference) direct-path Phase 3 backend. |
 
 Other files of interest:
 
@@ -386,6 +395,7 @@ Other files of interest:
 | Phase 1 evaluator | `tla_eval/evaluation/syntax/compilation_check.py` |
 | Phase 2 evaluator | `tla_eval/evaluation/semantics/runtime_check.py` |
 | Phase 3 evaluator | `tla_eval/evaluation/semantics/transition_validation.py` |
+| Phase 3 trace loader (direct path) | `tla_eval/evaluation/semantics/trace_loader.py` |
 | Phase 4 evaluator | `tla_eval/evaluation/semantics/manual_invariant_evaluator.py` |
 | Generation method | `tla_eval/methods/direct_call/method.py` |
 | Metric registry | `tla_eval/evaluation/base/metric_registry.py` |

--- a/docs/js_sam_backend_spec.md
+++ b/docs/js_sam_backend_spec.md
@@ -1,0 +1,477 @@
+# JS-SAM Language Backend — Specification
+
+**Status:** Implemented (first cut) — see §11 for the implementation map
+**Author:** JJ Dubray (jdubray@gmail.com)
+**Date:** 2026-06-09
+**Depends on:** `docs/add_new_spec_language.md` (the integration contract this spec instantiates)
+
+---
+
+## 1. Summary
+
+Add a fourth specification language to SysMoBench: **JavaScript using the SAM
+pattern** ([sam.js.org](https://sam.js.org)), via the
+[`@cognitive-fab/sam-pattern`](https://www.npmjs.com/package/@cognitive-fab/sam-pattern)
+and [`@cognitive-fab/sam-fsm`](https://www.npmjs.com/package/@cognitive-fab/sam-fsm)
+npm packages.
+
+SAM is grounded in TLA+ semantics — actions present proposals, a model accepts
+or rejects them, state is a pure function of the model — but the artifact is an
+**executable `.js` module**, not formal-spec source. This is the bench's first
+non-formal-language backend, and it tests a distinct hypothesis:
+
+> Can LLMs produce correct system specifications in a pattern they see
+> constantly in training data (JavaScript), rather than in formal languages
+> (TLA+, Alloy, CSP) they rarely see?
+
+### Hypothesis & success measure
+
+The backend is informative if, on the same task with the same models, JS-SAM
+scores diverge measurably from the formal-language scores in either direction.
+Either outcome is a publishable signal:
+
+- JS-SAM ≫ formal languages → familiarity with the host language dominates
+  spec quality; formal syntax is the bottleneck.
+- JS-SAM ≈ or ≪ formal languages → the hard part is modeling, not syntax.
+
+---
+
+## 2. Scope
+
+### In scope (first cut)
+
+| Item | Decision |
+|------|----------|
+| Target task | `spin` only (Asterinas spinlock) — parity with Alloy and PAT's historical scope |
+| Generation method | `direct_call` (one prompt) |
+| Invariants | Three starter invariants drawn from the generic spinlock set (see §8) |
+| In-context example | Rocket Launcher — the SAM community's canonical small system |
+| Phases | All four (Phase 3 via the **direct path**, a bench first — see §7) |
+| Agent translators | Remapped to a direct API call, same as Alloy (`alloy.py:358`) and PAT (`pat.py:340`) |
+
+### Out of scope (first cut)
+
+- Tasks beyond `spin`. (Candidate second target: `ringbuffer` or `locksvc`
+  for richer control state — deferred until the team answers Open Question 2.)
+- A real agent-based invariant translator (no backend has one except TLA+;
+  see Open Question 4).
+- Extending the TLA+-shaped `tv-eval` agent skill — the direct path makes it
+  unnecessary for JS-SAM.
+- Leaderboard weighting changes. JS-SAM reuses the existing metric weights
+  (syntax 0.15, runtime 0.15, transition 0.35, invariant 0.35).
+- TypeScript output, browser execution, or any UI concern. The spec artifact
+  is a plain Node-executable module.
+
+---
+
+## 3. Architecture
+
+One `LanguageBackend` subclass plus a small Node helper the Python side shells
+out to with JSON-in / JSON-out — the same shape as the Alloy backend (Java
+helpers over `lib/alloy.jar`) and the PAT backend (`mono PAT3.Console.exe`).
+
+```
+tla_eval/languages/js_sam.py          # JsSamBackend(LanguageBackend) + register()
+tools/js-sam/                          # Node helper (the "checker binary")
+  package.json                         # pins @cognitive-fab/sam-pattern, @cognitive-fab/sam-fsm
+  package-lock.json
+  cli.mjs                              # subcommands: validate | check | transitions | invariants
+tla_eval/tasks/spin/prompts/js-sam/   # per-language prompts (loader lowercases name)
+  direct_call.txt
+  agent_correction.txt
+data/js_sam_invariant_templates/spin/
+  invariants.yaml                      # `javascript_example` snippet field
+tests/test_languages/test_js_sam.py   # backend unit tests (TDD)
+tests/fixtures/js_sam/                 # known-good / known-bad sample specs, synthetic traces
+```
+
+Evaluator-side work (the one exception to "no evaluator changes"):
+
+```
+tla_eval/evaluation/semantics/trace_loader.py          # NEW — language-neutral NDJSON loader + windower
+tla_eval/evaluation/semantics/transition_validation.py # implement the stubbed direct path (lines 86–94)
+```
+
+### Helper protocol
+
+Every `cli.mjs` subcommand reads a single JSON request on stdin and writes a
+single JSON response on stdout. Exit code 0 means "the helper ran" — pass/fail
+is carried in the JSON (`{"success": bool, "errors": [...], ...}`), mirroring
+how the PAT backend text-detects failures because PAT always exits 0. Crashes
+(non-zero exit, malformed JSON) are reported as tooling errors, not spec
+failures.
+
+### Backend identity fields
+
+| Field | Value | Rationale |
+|-------|-------|-----------|
+| `name` | `"JS-SAM"` | Distinguishes the pattern from generic JavaScript |
+| `aliases` | `("js-sam", "jssam", "sam", "javascript-sam")` | Case-insensitive CLI resolution |
+| `fence_label` | `"javascript"` | Models emit ```` ```javascript ```` fences natively; fighting that costs Phase 1 points for the wrong reason |
+| `config_fence_label` | `None` | No separate config artifact (like Alloy/PAT) |
+| `spec_extension` | `".js"` | CommonJS for the first cut (see §4 module contract) |
+| `config_extension` | `None` | — |
+| `invariant_template_dirname()` | `"js_sam_invariant_templates"` | Parallel to `alloy_invariant_templates` |
+| `invariant_example_field()` | `"javascript_example"` | Default derivation from `fence_label` — no override needed |
+
+`check_available()` verifies: `node --version` ≥ the pinned engine,
+`tools/js-sam/node_modules` present (or runs `npm ci` guidance), and returns a
+one-line actionable message on failure — same pattern as
+`AlloyBackend.check_available` / `PATBackend.check_available`.
+
+---
+
+## 4. The generated-spec module contract
+
+The prompt instructs the model to emit one fenced `javascript` block that is a
+CommonJS module with this export shape:
+
+```js
+module.exports = {
+  instance,       // the SAM instance (createInstance({ hasAsyncActions: false }))
+  init,           // () => void — (re)initialize the model to its initial state
+  actions,        // { AcquireLock: (data) => void, ReleaseLock: (data) => void, ... }
+  getState,       // () => object — pure JSON-serializable snapshot of the model
+  setState,       // (snapshot) => void — force the model to a given snapshot (Phase 3)
+  checkerIntents, // [{ name, intent, values }] — explorer descriptors (Phases 2 & 4)
+};
+```
+
+> **Contract update vs the original draft.** The draft proposed four exports;
+> validating against `@cognitive-fab/sam-pattern@1.6.1` showed the bundled
+> `checker()` needs the SAM `instance` plus intent descriptors with value
+> domains (`{ intent, name, values }`, exactly as in the library's Die Hard
+> example), so the contract carries six exports. `values` is the action's
+> input domain — for spin, every `{thread, callType}` combination — which is
+> genuinely part of the model, like a TLA+ constants block.
+
+Contract rules (enforced structurally in Phase 1, semantically in Phases 2–4):
+
+1. `actions` MUST contain one function per name in
+   `task.yaml > tv.target_actions` (for `spin`: `AcquireLock`, `ReleaseLock`).
+   This is the same hard contract every language's prompt carries
+   (`add_new_spec_language.md` §5).
+2. `getState()` MUST return a plain JSON-serializable object — no functions,
+   no classes, no cycles. This is what trace states are diffed against.
+3. `setState(snapshot)` MUST be a legal entry point for any snapshot
+   `getState()` could produce. It exists solely so Phase 3 can replay
+   `(pre, action, post)` windows without searching for a path to `pre`.
+4. The module MUST NOT perform I/O, use timers, or depend on wall-clock time
+   or randomness. Violations surface as Phase 2/3 nondeterminism failures.
+
+> **Resolved (was TBD):** the construction idiom was validated against the
+> installed packages (`sam-pattern 1.6.1`, `sam-fsm 1.0.0`). The prompt's
+> Rocket Launcher example pins it: `createInstance({ hasAsyncActions: false })`
+> (synchronous steps are mandatory), plain actions returning proposals with
+> `__name` set, guard-style acceptors, `getState` via a sanitizing
+> `JSON.stringify` replacer over `instance({}).state()`, and `setState` via
+> `instance({ initialState: clone(snapshot) })` (the library's
+> `addInitialState` merges into the live model). Notable library behaviors
+> the helper accounts for: acceptors run inside an async wrapper, so acceptor
+> throws surface as unhandled promise rejections (captured by the helper, not
+> fatal); gated actions reject by presenting `__error: 'unexpected action …'`,
+> which the helper treats as legal rejection rather than a runtime fault.
+
+---
+
+## 5. User stories — backend
+
+Stories follow the bench's four phases. "Helper" means `tools/js-sam/cli.mjs`.
+
+### US-1 — Backend registration
+
+**Description:** As a bench maintainer, I want `--language JS-SAM` resolved by
+the existing registry so that no CLI or evaluator plumbing changes are needed.
+
+**Acceptance criteria:**
+- `tla_eval/languages/js_sam.py` subclasses `LanguageBackend`, sets the
+  identity fields in §3, and calls `register(JsSamBackend())` at import side.
+- `from tla_eval.languages import get; get("js-sam")`, `get("SAM")`, and
+  `get("JS-SAM")` all return the backend (auto-discovery via the lazy
+  bootstrap — no `__init__.py` edit).
+- `get("JS-SAM").check_available()` returns `None` on a machine with Node and
+  installed helper deps, and an actionable one-liner (naming the missing tool
+  and the install command) otherwise.
+- The default `extract_artifacts()` pulls the spec from a
+  ```` ```javascript ```` fence with no override.
+
+### US-2 — Phase 1: syntax / structural check
+
+**Description:** As a model evaluator, I want a generated JS-SAM spec
+parse-checked and structurally validated so that Phase 1 measures "is this a
+well-formed SAM module" and not merely "is this JavaScript".
+
+**Acceptance criteria:**
+- `validate_syntax()` writes the spec to `work_dir / spec_filename` (or a
+  default name) and invokes `cli.mjs validate`.
+- The helper performs, in order, reporting the first failure class:
+  1. **Parse check** — load the file; a `SyntaxError` populates
+     `SyntaxOutcome.syntax_errors` with message + line number.
+  2. **Load check** — `require()` the module in a fresh process; import-time
+     throws populate `semantic_errors`.
+  3. **Structural check** — exports match the §4 contract: `init`, `actions`,
+     `getState`, `setState` present and callable; `actions` contains every
+     name from the request's `target_actions` list; missing/extra-typed
+     exports populate `semantic_errors` with one entry per violation.
+- A known-good fixture spec yields `SyntaxOutcome(success=True)`; fixtures
+  with (a) a syntax error, (b) an import-time throw, (c) a missing target
+  action each yield `success=False` with the correct error class populated.
+- Helper crash or timeout yields `success=False` with `error_message` set and
+  empty error lists (tooling failure, not spec failure).
+
+### US-3 — Phase 2: bounded behavior exploration
+
+**Description:** As a model evaluator, I want the spec's own state space
+explored by the SAM behavior explorer so that Phase 2 measures whether the
+model terminates cleanly under bounded exploration — the same question TLC,
+AlloyRuntime, and PAT answer for the other languages.
+
+**Acceptance criteria:**
+- `run_model_checker()` invokes `cli.mjs check` with the spec path, the
+  depth bound, and the timeout; no separate config artifact is required
+  (the base `generate_default_config()` returning `(True, "", None)` is
+  used unchanged, like Alloy/PAT).
+- The depth bound defaults to **`depthMax: 6`** (the sam-pattern explorer
+  default) and is read from a single bench-side constant so changing it later
+  is a config edit, not a code change. The effective bound is recorded in
+  `ModelCheckOutcome.raw_output`. (Bench-wide vs per-task is Open Question 3;
+  the first cut hardcodes bench-wide.)
+- Exploration that completes without an acceptor exception, unhandled throw,
+  or non-serializable state yields `success=True`.
+- Failures populate `classification` with one of:
+  `"violation"` (an explorer-detected predicate/acceptor failure),
+  `"runtime_error"` (unhandled throw during an action or present),
+  `"nondeterminism"` (two runs from the same state diverge),
+  `"timeout"`, `"parse_error"` — aligning with the classification vocabulary
+  TLA+ already emits so downstream aggregation needs no changes.
+- The whole exploration respects the evaluator's `timeout`; the helper is
+  killed and `classification="timeout"` reported if exceeded.
+
+### US-4 — Phase 3: direct transition validation
+
+**Description:** As a model evaluator, I want each captured
+`(pre_state, action, post_state)` trace window replayed against the SAM model
+directly — `setState(pre)`, `actions[name](data)`, diff `getState()` against
+`post` — so that Phase 3 needs no coding-agent orchestration and costs
+seconds, not the agent path's "30 min to several hours and $1–4".
+
+**Acceptance criteria:**
+- `JsSamBackend.supports_direct_transition_validation = True` — the first
+  backend in the bench to set it.
+- `validate_transitions(spec_path, trace_windows, work_dir, timeout)` batches
+  windows to `cli.mjs transitions` and returns a `TransitionOutcome` with
+  `per_action_pass_rates`, `total_passed`, `total_windows` populated.
+- Per-window semantics: a window **passes** iff `setState(pre_state)` then
+  `actions[action](data)` completes without throwing AND the resulting
+  `getState()` matches `post_state` under the **projection rule**: every key
+  present in the trace's `post_state` must be deeply equal in the model's
+  state; model-only auxiliary keys are ignored. (Rationale: SAM models may
+  carry bookkeeping the instrumented kernel doesn't emit; the trace is the
+  source of truth for the variables it covers. This mirrors how the tv-eval
+  agent skill maps trace variables onto spec variables rather than requiring
+  bijection.)
+- A window whose `action` is absent from the module's `actions` map counts as
+  failed for that action group (not a tooling error) — the prompt made the
+  action names a hard contract.
+- A deterministic synthetic-trace fixture exists in `tests/fixtures/js_sam/`:
+  a hand-written correct spin model passes 100% of a hand-written NDJSON
+  trace; a deliberately broken model (e.g. `ReleaseLock` that doesn't clear
+  the holder) fails exactly the windows that exercise the bug.
+
+### US-5 — Phase 4: invariant translation and checking
+
+**Description:** As a model evaluator, I want the expert spinlock invariants
+translated into JavaScript predicates over the spec's own state shape and
+checked by the behavior explorer, so that Phase 4 measures whether the
+generated model is *verifiable*, not just runnable.
+
+**Acceptance criteria:**
+- `translate_invariants()` supports `translator="claude"` and explicit direct
+  model names via `model.generate_direct()`; `"claude-code"` and `"codex"`
+  are remapped to the direct call with a code comment marking the remap —
+  byte-for-byte the same policy as `pat.py:330-369`. Unsupported modes return
+  `({}, "translator '<x>' not supported by JS-SAM backend")`.
+- A translated invariant is a JavaScript predicate of shape
+  `(state) => boolean` (safety) — the translation prompt includes the spec
+  source so the predicate is written against the *generated* state shape,
+  not an assumed one.
+- `check_invariants()` invokes `cli.mjs invariants`, which runs the behavior
+  explorer with each predicate installed as a safety check, and returns one
+  `InvariantCaseResult` per template: `success`, the `translated` text, the
+  explorer's `raw_output`, and on failure a counterexample trace prefix in
+  `metadata["counterexample"]`.
+- A template with no matching `translated` entry is reported as a translation
+  failure (per the `base.py:check_invariants` docstring), not silently
+  skipped.
+- Liveness templates: the first cut declares **safety-only**, matching
+  Alloy's precedent (`data/alloy_invariant_templates/spin/invariants.yaml`
+  metadata: "Liveness properties are not included as Alloy performs bounded
+  model checking"). The bounded explorer has the same limitation. The
+  invariants.yaml metadata note states this explicitly.
+
+### US-6 — Prompts and in-context example
+
+**Description:** As a bench maintainer, I want JS-SAM prompts for `spin` that
+carry the same hard contracts as the other languages' prompts so that
+generation failures are attributable to the model, not the harness.
+
+**Acceptance criteria:**
+- `tla_eval/tasks/spin/prompts/js-sam/direct_call.txt` exists (resolution
+  path 1 from `add_new_spec_language.md` §5; no legacy fallback applies to
+  non-TLA+ languages — a missing prompt is a hard error, which the test
+  suite asserts).
+- The prompt specifies: (1) the ```` ```javascript ```` fence, (2) the
+  mandatory action names `AcquireLock` / `ReleaseLock` from
+  `task.yaml > tv.target_actions`, (3) the §4 export contract verbatim,
+  (4) the no-I/O / no-randomness determinism rules, and (5) the complete
+  **Rocket Launcher** SAM model as the in-context example (sourced from
+  [sam-samples](https://github.com/jdubray/sam-samples), adapted to the §4
+  contract).
+- `tla_eval/tasks/spin/prompts/js-sam/agent_correction.txt` exists and
+  reuses `fence_format_hint()`'s single-block phrasing (the base default —
+  no override needed).
+
+### US-7 — Starter invariant templates
+
+**Description:** As a model evaluator, I want a `spin` invariant library for
+JS-SAM so that Phase 4 is exercisable on day one.
+
+**Acceptance criteria:**
+- `data/js_sam_invariant_templates/spin/invariants.yaml` exists with **three**
+  starter invariants, drawn from the generic set the Alloy library already
+  defines: `MutualExclusion`, `LockStatusConsistency`, `NoDeadlock`
+  (all `type: "safety"`).
+- Each entry carries `name`, `type`, `natural_language`,
+  `formal_description` (reused verbatim from the Alloy library where
+  applicable) and a `javascript_example` reference snippet written against a
+  *plausible* state shape, labeled as illustrative — the translator rewrites
+  it against the actual generated spec.
+- Parity note recorded in the YAML metadata: Alloy ships 6 invariants for
+  spin (4 generic + 2 Asterinas-specific: `TryLockNonBlocking`,
+  `BlockingVsNonBlockingSemantics`); extending JS-SAM from 3 → 6 is a
+  follow-up item, not first-cut scope.
+
+---
+
+## 6. User stories — evaluator (the one cross-cutting change)
+
+### US-8 — Implement the direct-path wrapper in `TransitionValidationEvaluator`
+
+**Description:** As a bench maintainer, I want the stubbed direct path in
+`transition_validation.py:86-94` implemented so that any backend declaring
+`supports_direct_transition_validation = True` gets traces loaded, windowed,
+and dispatched — JS-SAM is the first consumer, but the wrapper must be
+language-neutral.
+
+**Acceptance criteria:**
+- A new language-neutral `trace_loader.py` module:
+  - resolves the trace directory from `task.yaml > traces_folder`
+    (for `spin`: `data/sys_traces/spin`),
+  - parses NDJSON trace files and yields `(action, pre_state, post_state)`
+    windows matching the `base.py:259` signature,
+  - filters to `task.yaml > tv.target_actions`,
+  - raises a clear error (not an empty iterator) when the trace folder is
+    missing or empty — see the dependency note below.
+- `TransitionValidationEvaluator.evaluate()` replaces the lines 86–94 stub:
+  when `backend.supports_direct_transition_validation`, it loads windows via
+  the trace loader, calls `backend.validate_transitions(...)` with the
+  configured timeout, and maps `TransitionOutcome` into
+  `TransitionValidationResult` (`per_action_pass_rates`, `total_passed` →
+  `total_passed`, `total_windows` → `total_windows`, score =
+  passed/windows, `overall_success` per the existing policy at line 208).
+- The agent path is untouched: TLA+/Alloy/PAT runs through
+  `launch_tv_eval.sh` exactly as before (regression-tested).
+- **Contract clarification to land with this change:** the code comment at
+  `transition_validation.py:87-88` says "Trace loading + windowing is the
+  backend's responsibility", but the `base.py:256-262` signature passes
+  `trace_windows` *in* — i.e. the evaluator owns loading. This spec resolves
+  the contradiction in favor of the signature (loader is shared and
+  language-neutral; windows-in is the contract); the stale comment and
+  `add_new_spec_language.md` §3.3 are updated in the same PR.
+
+**Dependency / risk:** `data/sys_traces/spin` is referenced by `task.yaml`
+but **not checked into the repository** — traces are produced by the Docker/
+QEMU instrumentation harness (`tv.harness` in `task.yaml`). Phase 3
+end-to-end therefore requires either (a) running the trace-capture harness,
+or (b) the maintainers publishing the captured traces. The unit-test story
+(US-4) is insulated from this via synthetic fixture traces, but the
+*leaderboard* Phase 3 number is blocked on real traces. Flag on the
+integration thread alongside the PR.
+
+---
+
+## 7. Why the direct path (and not the agent path)
+
+`add_new_spec_language.md` §3.3 offers two Phase 3 routes. The agent path
+requires extending the TLA+-shaped `tv-eval` skill — "a larger project than
+writing a backend" per the doc — and costs $1–4 plus up to hours per run.
+JS-SAM is the textbook direct-path case the doc anticipates: the language's
+own runtime answers "does `pre ∧ action ⇒ post'` hold?" by construction,
+because SAM **is** `model.present(action(data))` — trace replay reduces to
+`setState(pre)`, `actions[name](data)`, state diff. No orchestration, no
+search, no LLM in the loop. This is also why US-8 lands with this backend:
+the doc explicitly assigns trace-loader threading to "the first language
+that uses it."
+
+---
+
+## 8. Test plan (TDD)
+
+Per project convention, tests precede implementation:
+
+| Layer | Tests | Fixtures |
+|-------|-------|----------|
+| Helper (`cli.mjs`) | Node-side unit tests per subcommand: good/bad parse, structural violations, explorer pass/violation/timeout, window pass/fail/projection | `tests/fixtures/js_sam/specs/*.js` |
+| Backend (`js_sam.py`) | Python unit tests mocking the subprocess boundary: JSON marshalling, outcome mapping, error-class routing, `check_available` messages | canned helper JSON responses |
+| Evaluator (US-8) | Trace loader: NDJSON parsing, windowing, action filtering, missing-folder error. Direct-path dispatch with a stub backend. Agent-path regression (TLA+ unaffected) | `tests/fixtures/js_sam/traces/*.ndjson` (synthetic) |
+| End-to-end | The §6 checkpoint from `add_new_spec_language.md`: `run_benchmark.py --metric compilation_check --language JS-SAM --spec-file <fixture>` produces the expected log sequence and experiment directory | hand-written correct spin model |
+
+---
+
+## 9. Open questions for the team (decision log)
+
+| # | Question | First-cut position pending decision |
+|---|----------|--------------------------------------|
+| 1 | Does the bench want a runtime-pattern language at all? The leaderboard story shifts: "did the LLM write a working SAM model" vs "a sound TLA+ spec". | Proceed to spec/scaffold; hold the PR merge on this answer. The architecture (`add_new_spec_language.md`) was built expecting a direct-path language, so the plumbing investment (US-8) benefits any future backend regardless. |
+| 2 | Is `spin` the right first target, or would richer control state (>2 target actions) differentiate models better? | `spin` first for Alloy/PAT comparability; `ringbuffer`/`locksvc` as the documented second target. |
+| 3 | Depth bound governance: `depthMax: 6` default — per-task, per-language, or bench-wide? | Bench-wide constant recorded in run output (US-3); revisit when a second task lands. |
+| 4 | Real agent paths for invariant translation — anyone planning to wire them for Alloy/PAT? If so, share infrastructure instead of three remaps. | JS-SAM remaps to direct calls like Alloy/PAT today; `AgentInvariantTranslator` (TLA+) is the generalization point if/when. |
+| 5 | Trace availability: will maintainers publish captured `spin` NDJSON traces, or is harness execution expected per-evaluator? | Blocks leaderboard Phase 3 only; unit tests use synthetic fixtures (§6 risk note). |
+
+---
+
+## 10. Non-functional requirements
+
+- **Determinism:** two runs of any phase on the same spec produce identical
+  outcomes (modulo timing fields). The helper sets no ambient state; the spec
+  contract (§4 rule 4) bans nondeterminism sources, and Phase 2 actively
+  classifies violations.
+- **Isolation:** generated specs are untrusted code. The helper executes them
+  in a child Node process with no network access expected and a hard
+  wall-clock kill at the evaluator's `timeout`. (Full sandboxing — `--frozen-
+  intrinsics`, OS-level isolation — is noted as a hardening follow-up; the
+  bench already executes model-generated TLA+/Alloy/PAT through their
+  checkers under the same trust model.)
+- **Portability:** Node ≥ 20 LTS, pinned in `tools/js-sam/package.json`
+  `engines`. No mono/Java dependency — JS-SAM is the bench's easiest backend
+  to install, which `check_available()` should make visible.
+- **Cost:** Phases 1–3 are LLM-free at evaluation time (generation aside).
+  Phase 4 makes one direct API call per run for translation, mirroring
+  Alloy/PAT cost shape.
+
+---
+
+## 11. Implementation map (first cut, landed with this spec)
+
+| Spec item | Implementation |
+|-----------|----------------|
+| US-1 backend + registry | `tla_eval/languages/js_sam.py` (auto-discovered; `js-sam`/`sam`/`jssam` aliases) |
+| US-2–US-5 helper | `tools/js-sam/cli.mjs` (`ping` / `validate` / `check` / `transitions` / `invariants`), deps pinned in `tools/js-sam/package.json` (incl. unscoped `sam-pattern`/`sam-fsm` aliases for require-resolution resilience) |
+| US-6 prompts | `tla_eval/tasks/spin/prompts/js-sam/{direct_call,agent_correction,phase3_invariant_implementation}.txt` |
+| US-7 templates | `data/js_sam_invariant_templates/spin/invariants.yaml` (3 starters + parity note) |
+| US-8 evaluator | `tla_eval/evaluation/semantics/trace_loader.py` (new) + direct path in `transition_validation.py` (`_evaluate_direct`); stale "backend's responsibility" comment resolved in favor of the `base.py` windows-in signature |
+| §8 tests | `tests/test_languages/test_js_sam.py`, `tests/test_evaluation/test_trace_loader.py`, fixtures under `tests/fixtures/js_sam/` (29 tests) |
+| Incidental fix | `scripts/run_benchmark.py`: the unconditional TLA+ (java + tla2tools.jar) prerequisite gate is now applied only when `--language` is TLA+; other backends rely on their own `check_available()` |
+
+Phase 2/4 exploration cost on the reference spin model: ~6.5k steps at
+`depthMax 4`, ~327k steps (~2.7 s) at the bench-wide `depthMax 6`.

--- a/docs/js_sam_backend_spec.md
+++ b/docs/js_sam_backend_spec.md
@@ -446,15 +446,22 @@ Per project convention, tests precede implementation:
   outcomes (modulo timing fields). The helper sets no ambient state; the spec
   contract (§4 rule 4) bans nondeterminism sources, and Phase 2 actively
   classifies violations.
-- **Isolation:** generated specs are untrusted code. The helper executes them
-  in a child Node process with no network access expected and a hard
-  wall-clock kill at the evaluator's `timeout`. (Full sandboxing — `--frozen-
-  intrinsics`, OS-level isolation — is noted as a hardening follow-up; the
-  bench already executes model-generated TLA+/Alloy/PAT through their
-  checkers under the same trust model.)
-- **Portability:** Node ≥ 20 LTS, pinned in `tools/js-sam/package.json`
-  `engines`. No mono/Java dependency — JS-SAM is the bench's easiest backend
-  to install, which `check_available()` should make visible.
+- **Isolation:** generated specs are untrusted **native code** — the helper
+  `require()`s the spec module and `eval()`s its invariant predicates, unlike
+  the restricted modelling languages the TLA+/Alloy/PAT checkers consume. Every
+  helper invocation therefore runs inside a throwaway Docker container
+  (`tla_eval/languages/js_sam.py:_run_helper`): `--network none` (no egress),
+  `--read-only` rootfs with only the spec file bind-mounted read-only, a
+  non-root `--user`, `--memory`/`--cpus`/`--pids-limit` caps, and the
+  evaluator's hard wall-clock `timeout`. The container is the trust boundary;
+  the host is never exposed to model code. A hostile spec that tries to write
+  the filesystem or open a socket fails inside the container and surfaces as an
+  ordinary spec error.
+- **Portability:** no mono/Java dependency. The helper runs in Docker (already
+  a bench-wide dependency for the trace harnesses) using the `node:20-slim`
+  image, with `tools/js-sam` dependencies installed via `npm ci`. Node ≥ 20 is
+  pinned in `package.json` `engines` and supplied by the image. `check_available()`
+  reports a missing daemon, image, helper, or `node_modules`.
 - **Cost:** Phases 1–3 are LLM-free at evaluation time (generation aside).
   Phase 4 makes one direct API call per run for translation, mirroring
   Alloy/PAT cost shape.

--- a/docs/js_sam_walkthrough.md
+++ b/docs/js_sam_walkthrough.md
@@ -231,6 +231,39 @@ The full pre-existing suite was run with and without our changes: the same
 (model-provider config tests, unrelated to this work). Nothing we touched
 regressed.
 
+### A live benchmark run with Claude (2026-06-09)
+
+After the fixture-based validation above, the pipeline was exercised with a
+real model: **claude-sonnet-4-20250514** generated a JS-SAM spec for the
+`spin` task from the actual Asterinas Rust source
+(`run_benchmark.py --language JS-SAM`, real generation, no `--spec-file`).
+
+| Stage | Result | Detail |
+|---|---|---|
+| Generation | valid on attempt 1 of 3 | 15.0 s, 3,922 prompt + 1,293 completion tokens, no correction loop |
+| Phase 1 — syntax/contract | PASS | 0 syntax errors, 0 semantic errors, 0.09 s |
+| Phase 2 — exploration | PASS | depth 6, ~4 s, no runtime errors, no nondeterminism |
+| Phase 4 — invariants | PASS 3/3 | live translation by Claude (3.3 s) + explorer checks (5.5 s): MutualExclusion, LockStatusConsistency, NoDeadlock |
+| Phase 3 — traces | not run | captured `spin` traces not in the repository (open question on the PR) |
+
+The generated spec was the model's own modeling, not a copy of the prompt's
+Rocket Launcher example. Its most interesting decision: a **reactor** that
+grants the freed lock to a spinning thread the instant `ReleaseLock` fires —
+a defensible reading of "the thread spins until acquisition," but it makes
+lock hand-off atomic with the release step. In the real system's traces a
+release leaves the waiting thread `trying` until its *own* next CAS attempt
+wins. Phases 1, 2, and 4 cannot see that divergence; trace validation exists
+precisely to catch it — concrete evidence for why the trace-availability
+question matters most for the JS-SAM leaderboard number.
+
+The run also surfaced one fix now included in this branch:
+`config/models.yaml` requested `max_tokens: 200000` for the `claude` entry,
+which the Anthropic API rejects for claude-sonnet-4 (output cap 64,000).
+Lowered to 64,000 with a dated probe note, matching the style of the
+existing `deepseek_tencent` comment. The same `claude` entry is the
+translator Alloy's and PAT's Phase 4 remaps rely on, so the fix is not
+JS-SAM-specific.
+
 ## 6. What is demonstrated — and what is not yet
 
 **Demonstrated:**
@@ -247,18 +280,21 @@ regressed.
 - The whole thing runs on a machine with only Node and Python (no Java, no
   mono).
 
+**Also demonstrated (live run, see §5):** one real model (claude-sonnet-4)
+generating a spec that passes Phases 1, 2, and 4 first-try, including the
+live invariant-translation API path.
+
 **Not yet demonstrated (the honest gaps):**
 
-- **No LLM has actually been benchmarked yet.** Everything above validates
-  the *measurement instrument* with hand-written specs. The hypothesis test
-  itself — generate specs with real models and compare JS-SAM scores to
-  TLA+/Alloy/PAT — needs API keys and is the natural next step.
+- **The hypothesis itself is untested.** One model passing one task is an
+  existence proof that the pipeline works end to end with real generation —
+  not the comparison. The actual experiment is multiple models, multiple
+  runs, JS-SAM scores side by side with TLA+/Alloy/PAT on the same task.
 - **Phase 3 leaderboard numbers are blocked on real traces.** The captured
   `spin` traces aren't in the repository; our tests use synthetic ones.
-  Raised with the maintainers as an open question on the PR.
-- **Invariant translation** (LLM rewrites the expert invariants against a
-  generated spec's state shape) is implemented and its parsing is tested,
-  but the live API call path hasn't been exercised.
+  Raised with the maintainers as an open question on the PR. The live run
+  makes this concrete: the generated spec's instant-handoff reactor would
+  plausibly diverge from real traces, and only Phase 3 can adjudicate that.
 - Three invariants vs Alloy's six for spin; the depth bound (6) is a single
   bench-wide constant. Both flagged as deliberate first-cut choices.
 

--- a/docs/js_sam_walkthrough.md
+++ b/docs/js_sam_walkthrough.md
@@ -1,0 +1,284 @@
+# JS-SAM in SysMoBench — A Walkthrough From Scratch
+
+*What was built, what was tested, and what it actually demonstrates.*
+
+---
+
+## 1. The project this plugs into
+
+**SysMoBench** (github.com/specula-org/SysMoBench) is a benchmark that asks one
+question: *can an AI model read the source code of a real system and write a
+correct formal specification of its behavior?*
+
+It ships 11 real systems as tasks — OS synchronization primitives from the
+Asterinas kernel (`spin`, `mutex`, `rwmutex`, `ringbuffer`) and distributed
+systems (`etcd`, `zookeeper`, `redisraft`, and others). A benchmark run works
+like this:
+
+1. **Generate.** An LLM is shown the system's source code (e.g. the Rust
+   spinlock from Asterinas) plus a task prompt, and asked to produce a
+   specification.
+2. **Phase 1 — Syntax.** Does the spec parse and type-check?
+3. **Phase 2 — Runtime.** A model checker explores the spec's own state
+   space. Does exploration terminate cleanly (no crashes, no deadlocks)?
+4. **Phase 3 — Trace validation.** The benchmark has traces captured from
+   the *real running system* — sequences of `(state before, action, state
+   after)`. Does the spec admit each real transition? This is the "is the
+   spec faithful to reality" test, weighted 35% of the score.
+5. **Phase 4 — Invariant verification.** Experts wrote invariants per system
+   in plain language ("at most one thread holds the lock"). They get
+   translated into the spec's vocabulary and checked. Also 35%.
+
+Everything language-specific lives behind one plugin interface called
+`LanguageBackend`. Before this work there were three backends, all **formal
+specification languages**: TLA+ (checked with TLC), Alloy (bounded relational
+checker), and PAT (CSP# process algebra). Adding a language means writing one
+backend subclass — the four phase evaluators never change.
+
+## 2. What we added and why
+
+We added a fourth language: **JS-SAM** — JavaScript using the
+[SAM pattern](https://sam.js.org) (State-Action-Model), via the
+`@cognitive-fab/sam-pattern` and `@cognitive-fab/sam-fsm` npm packages.
+
+SAM is a JavaScript programming pattern deliberately built on TLA+'s
+semantics: **actions** compute *proposals*, the **model** accepts or rejects
+each proposal in a single synchronized step, and **state** is a pure function
+of the model. So it has the same conceptual skeleton as a TLA+ spec — but the
+artifact is an executable `.js` module, not formal-language source.
+
+That makes it the benchmark's first *non-formal-language* backend, and it
+tests a genuinely different hypothesis:
+
+> LLMs have seen JavaScript constantly in training and TLA+/Alloy/CSP#
+> rarely. If models score much better in JS-SAM, formal *syntax* is the
+> bottleneck. If they score the same or worse, the hard part is *modeling*,
+> not syntax. Either result is informative.
+
+A practical bonus: `sam-pattern` ships its own bounded model checker (a
+"behavior explorer" that tries all action permutations to a depth limit), so
+Phases 2 and 4 need no external tool — and because a SAM model is literally
+`model.present(action(data))`, Phase 3 trace replay becomes trivial: put the
+model in the trace's pre-state, fire the action, diff the result against the
+trace's post-state.
+
+## 3. What was built
+
+### The module contract (what a generated spec must look like)
+
+A JS-SAM spec is a CommonJS module that must export six things:
+
+```js
+module.exports = {
+  instance,       // the SAM instance (synchronous mode is mandatory)
+  init,           // () => void — reset to the initial state
+  actions,        // { AcquireLock: (data) => void, ReleaseLock: (data) => void }
+  getState,       // () => plain JSON snapshot of the model
+  setState,       // (snapshot) => void — force the model into a given state
+  checkerIntents, // input domains for the explorer, e.g. every {thread, callType} combo
+};
+```
+
+Each export exists for a phase: `getState`/`setState` make Phase 3 replay
+possible, `instance` + `checkerIntents` are what the bundled explorer needs
+for Phases 2/4, and the structural check of this whole shape *is* Phase 1's
+semantic check. The action names (`AcquireLock`, `ReleaseLock` for the
+spinlock) are a hard contract from the task config — same rule as the other
+three languages.
+
+### The pieces (mirroring how Alloy and PAT are integrated)
+
+| Piece | File(s) | What it does |
+|---|---|---|
+| Node helper | `tools/js-sam/cli.mjs` | The "checker binary". Five subcommands (`ping`, `validate`, `check`, `transitions`, `invariants`), each reading one JSON request on stdin and writing one JSON response on stdout. |
+| Python backend | `tla_eval/languages/js_sam.py` | The `LanguageBackend` subclass. Maps each phase to a helper subcommand; auto-registered, so `--language JS-SAM` just works. |
+| Direct Phase 3 path | `tla_eval/evaluation/semantics/trace_loader.py` + the previously-stubbed branch in `transition_validation.py` | **First use in the bench.** TLA+/Alloy/PAT validate traces by launching a coding agent (30 min–hours, $1–4 per run). JS-SAM replays windows directly in seconds with no LLM involved. The trace loader (NDJSON → windows) is language-neutral so any future backend gets it for free. |
+| Prompts | `tla_eval/tasks/spin/prompts/js-sam/` | The generation prompt (with the contract and a complete **Rocket Launcher** example — the SAM community's canonical small system), a correction prompt, and the invariant-translation prompt. |
+| Invariant templates | `data/js_sam_invariant_templates/spin/invariants.yaml` | 3 starter safety invariants reused from the Alloy library: MutualExclusion, LockStatusConsistency, NoDeadlock. |
+
+Two incidental fixes the integration surfaced:
+
+- `scripts/run_benchmark.py` demanded Java + TLA+ tools for *every* language.
+  It now gates on them only when TLA+ is selected — a Node-only machine can
+  run JS-SAM end to end.
+- The docs and code disagreed about who loads traces for the direct Phase 3
+  path (a stub that had never been exercised). Resolved: the evaluator loads
+  and windows traces; the backend validates them.
+
+Two library quirks discovered by reading `sam-pattern`'s source, both handled
+in the helper: acceptor exceptions surface as unhandled promise rejections
+(which would otherwise kill the process — the helper captures and attributes
+them), and a rejected/gated action reports itself through the same error slot
+as a crash (the helper distinguishes "the model said no", which is legal,
+from "the model blew up", which is a failure).
+
+## 4. The samples
+
+### The reference spinlock model — `tests/fixtures/js_sam/specs/spin-good.js`
+
+A complete, hand-written JS-SAM spec of the Asterinas spinlock — effectively
+the "gold answer" for the spin task. Its state:
+
+```js
+{
+  lockHeld: false,                              // is the lock taken?
+  lockHolder: null,                             // which thread holds it (0, 1, or null)
+  threadStatus: { 0: 'idle', 1: 'idle' },       // idle | trying | locked
+  callType: { 0: null, 1: null },               // pending blocking call, if any
+}
+```
+
+It models the semantic distinction the benchmark cares about most:
+**`lock()` blocks** (a thread that loses the CAS race goes to `'trying'` and
+spins) while **`try_lock()` never blocks** (a loser goes straight back to
+`'idle'`). Guards make invalid operations no-ops — e.g. a release by a thread
+that doesn't hold the lock changes nothing, which is exactly how you want a
+model to behave under exhaustive exploration.
+
+### Five deliberately broken samples
+
+Each exists to prove one failure path is *detected and correctly classified*:
+
+| Fixture | The defect | What must catch it |
+|---|---|---|
+| `spin-syntax-error.js` | unbalanced brace | Phase 1, as a **syntax** error |
+| `spin-load-error.js` | throws while being imported | Phase 1, as a **load** error |
+| `spin-missing-export.js` | no `setState`, no `checkerIntents` | Phase 1, as **contract** violations (one message per missing export) |
+| `spin-bad-release.js` | `ReleaseLock` frees the lock but never clears `lockHolder`/status | Phase 3 — and *only* on release windows |
+| `spin-throwing.js` | an acceptor throws on a reachable state | Phase 2, classified `runtime_error` |
+
+### Synthetic traces
+
+Two small NDJSON files emulate what the real instrumentation harness
+produces: a **stream form** (one state snapshot per line; consecutive lines
+form windows) and an **event form** (each line carries its own pre/post
+state). The real captured traces for `spin` are *not* in the repository —
+they come from a Docker/QEMU harness — which is why synthetic ones were
+needed and why that gap is flagged to the maintainers (more in §6).
+
+### The Rocket Launcher
+
+Embedded in the generation prompt as the in-context example the LLM sees: a
+countdown (10 → 0), `Start` / `Decrement` / `Abort` actions, and a reactor
+that flips status to `launched` at zero. Small enough not to leak the
+spinlock solution, complete enough to teach the whole module contract.
+
+## 5. What was run, and what each run demonstrated
+
+### Direct helper smoke tests (run during development)
+
+- **Phase 2 on the good model:** explored **326,592 states in ~2.7 s** at the
+  bench depth bound of 6, twice (the second pass is a determinism check),
+  with zero violations. Demonstrates the bundled explorer is fast enough that
+  depth 6 costs seconds, not minutes.
+- **Phase 3 with a deliberately wrong expectation:** fed a window claiming a
+  failed `try_lock` leaves the thread `'trying'`. The replay failed exactly
+  that window with the pinpoint diff
+  `threadStatus.1: expected "trying", got "idle"` — demonstrating failures
+  come with actionable, field-level reasons.
+- **Phase 4 with one true and one false invariant:** `MutualExclusion`
+  passed; a deliberately false "the lock is never held" failed **with a
+  counterexample behavior** — the action sequence that reaches the violating
+  state — demonstrating the explorer produces evidence, not just a verdict.
+
+### The automated test suite — 29 tests, all passing
+
+`tests/test_languages/test_js_sam.py` (20 tests) and
+`tests/test_evaluation/test_trace_loader.py` (9 tests):
+
+- **Registration:** `js-sam`, `JS-SAM`, `SAM`, `jssam` all resolve to the
+  backend through the existing registry; both ```` ```javascript ```` and
+  ```` ```js ```` fences are extracted from model output.
+- **Phase 1:** the good spec passes; each broken fixture fails with the
+  *right class* of error (syntax vs load vs contract).
+- **Phase 2:** good spec explores cleanly; the throwing fixture is classified
+  `runtime_error` with the actual exception message surfaced.
+- **Phase 3:** the good spec passes all windows at 100%; the buggy-release
+  spec scores `AcquireLock: 1.0, ReleaseLock: 0.0` — the bug is detected
+  *and attributed to the right action*. Unknown actions count as failed
+  windows (the naming contract is enforced), and an empty window set is an
+  error rather than a silent vacuous pass.
+- **Phase 4:** pass/fail discrimination with counterexample metadata; a
+  template with no translation is reported as a translation failure, not
+  skipped.
+- **Trace loader:** both NDJSON forms parse; windows chain correctly
+  (each window's pre-state is the previous window's post-state); off-target
+  actions are filtered; missing/empty trace folders raise actionable errors
+  instead of producing an empty (and misleadingly perfect) result.
+- **Direct-path evaluator:** the full wiring — evaluator → trace loader →
+  backend → Node helper → score — produces correct totals and pass rates;
+  and the realistic failure mode (no captured traces in the repo) is
+  reported cleanly instead of crashing.
+
+### End-to-end CLI checkpoint (the integration doc's §6 acceptance test)
+
+```
+python scripts/run_benchmark.py --task spin --method direct_call --model claude \
+  --metric compilation_check --language JS-SAM \
+  --spec-file tests/fixtures/js_sam/specs/spin-good.js
+```
+
+produced the expected sequence — prompt resolved for `language=JS-SAM`,
+`Evaluating compilation (JS-SAM): spin/direct_call/claude`, experiment
+directory created under `output/compilation_check/js-sam/...`, and
+`Metric 'compilation_check': PASS`. This demonstrates the backend is wired
+into the real benchmark pipeline, not just unit-tested in isolation.
+
+### Regression check
+
+The full pre-existing suite was run with and without our changes: the same
+2 failures + 1 error exist in `tests/test_models/` on a clean checkout
+(model-provider config tests, unrelated to this work). Nothing we touched
+regressed.
+
+## 6. What is demonstrated — and what is not yet
+
+**Demonstrated:**
+
+- A non-formal, executable language fits the four-phase architecture with
+  zero changes to the evaluators' interfaces — one backend class + one
+  helper, exactly like Alloy and PAT.
+- The evaluation pipeline has *discriminative power* for JS-SAM: every
+  seeded defect class is caught, correctly classified, and attributed
+  (right phase, right action, right field, with counterexamples).
+- The direct Phase 3 path — designed into the architecture but never used —
+  works end to end, and cuts trace validation from "30 min–hours and $1–4
+  of agent spend" to seconds at zero marginal cost.
+- The whole thing runs on a machine with only Node and Python (no Java, no
+  mono).
+
+**Not yet demonstrated (the honest gaps):**
+
+- **No LLM has actually been benchmarked yet.** Everything above validates
+  the *measurement instrument* with hand-written specs. The hypothesis test
+  itself — generate specs with real models and compare JS-SAM scores to
+  TLA+/Alloy/PAT — needs API keys and is the natural next step.
+- **Phase 3 leaderboard numbers are blocked on real traces.** The captured
+  `spin` traces aren't in the repository; our tests use synthetic ones.
+  Raised with the maintainers as an open question on the PR.
+- **Invariant translation** (LLM rewrites the expert invariants against a
+  generated spec's state shape) is implemented and its parsing is tested,
+  but the live API call path hasn't been exercised.
+- Three invariants vs Alloy's six for spin; the depth bound (6) is a single
+  bench-wide constant. Both flagged as deliberate first-cut choices.
+
+## 7. Where everything stands
+
+- Branch `full-stack`, commit `0094a35` — 26 files, ~2,900 lines.
+- Pull request: **specula-org/SysMoBench#17**, opened from the fork
+  `jdubray/SysMoBench-1` (you lack write access to specula-org).
+- Design record: `docs/js_sam_backend_spec.md` (user stories, acceptance
+  criteria, decision log, implementation map).
+
+Try it yourself:
+
+```bash
+# tooling sanity check
+python -c "from tla_eval.languages import get; print(get('js-sam').check_available())"
+
+# the test suite
+python -m pytest tests/test_languages tests/test_evaluation -v
+
+# one helper call by hand (Phase 2 on the reference model)
+echo '{"specPath":"tests/fixtures/js_sam/specs/spin-good.js","depthMax":6}' | node tools/js-sam/cli.mjs check
+```

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -405,7 +405,10 @@ Examples:
             sys.exit(1)
         args.config_file = str(Path(args.config_file).resolve())
 
-    if not validate_prerequisites():
+    # TLA+ tooling (java + tla2tools.jar) is only a prerequisite for the TLA+
+    # backend; every other language validates its own tools through
+    # backend.check_available() just below.
+    if args.language.lower().replace("+", "").strip() == "tla" and not validate_prerequisites():
         sys.exit(1)
 
     # Backend availability check — fail fast before generation/evaluator setup

--- a/tests/fixtures/js_sam/specs/spin-bad-release.js
+++ b/tests/fixtures/js_sam/specs/spin-bad-release.js
@@ -1,0 +1,101 @@
+/**
+ * Fixture: deliberately buggy spin model — ReleaseLock flips lockHeld but
+ * never clears lockHolder or the thread status. Phase 3 must fail exactly
+ * the windows that exercise the release path; Phase 4 LockStatusConsistency
+ * must produce a counterexample.
+ */
+
+'use strict';
+
+const { createInstance } = require('@cognitive-fab/sam-pattern');
+
+const instance = createInstance({ instanceName: 'spin-bad', hasAsyncActions: false });
+
+const INITIAL_STATE = {
+  lockHeld: false,
+  lockHolder: null,
+  threadStatus: { 0: 'idle', 1: 'idle' },
+  callType: { 0: null, 1: null },
+};
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const { intents } = instance({
+  initialState: clone(INITIAL_STATE),
+  component: {
+    actions: [
+      ({ thread, callType = 'lock' } = {}) => ({ __name: 'AcquireLock', acquire: { thread, callType } }),
+      ({ thread } = {}) => ({ __name: 'ReleaseLock', release: { thread } }),
+    ],
+    acceptors: [
+      (model) => ({ acquire }) => {
+        if (acquire == null) return;
+        const { thread, callType } = acquire;
+        const id = String(thread);
+        if (model.threadStatus[id] === undefined || model.threadStatus[id] === 'locked') return;
+        if (!model.lockHeld) {
+          model.lockHeld = true;
+          model.lockHolder = thread;
+          model.threadStatus[id] = 'locked';
+          model.callType[id] = null;
+        } else if (callType === 'tryLock') {
+          model.threadStatus[id] = 'idle';
+          model.callType[id] = null;
+        } else {
+          model.threadStatus[id] = 'trying';
+          model.callType[id] = 'lock';
+        }
+      },
+      (model) => ({ release }) => {
+        if (release == null) return;
+        if (model.lockHolder !== release.thread) return;
+        // BUG: lock is freed but holder/status bookkeeping is never cleared.
+        model.lockHeld = false;
+      },
+    ],
+  },
+});
+
+const [acquireIntent, releaseIntent] = intents;
+
+const sanitizeReplacer = (key, value) => {
+  if (typeof key === 'string' && key.startsWith('__')) return undefined;
+  if (typeof value === 'function') return undefined;
+  return value;
+};
+
+const getState = () => JSON.parse(JSON.stringify(instance({}).state(), sanitizeReplacer));
+
+const setState = (snapshot) => {
+  instance({ initialState: clone(snapshot) });
+};
+
+const init = () => {
+  instance({}).state().clearError();
+  setState(INITIAL_STATE);
+};
+
+const actions = {
+  AcquireLock: (data = {}) => acquireIntent(data),
+  ReleaseLock: (data = {}) => releaseIntent(data),
+};
+
+const checkerIntents = [
+  {
+    name: 'AcquireLock',
+    intent: actions.AcquireLock,
+    values: [
+      [{ thread: 0, callType: 'lock' }],
+      [{ thread: 1, callType: 'lock' }],
+      [{ thread: 0, callType: 'tryLock' }],
+      [{ thread: 1, callType: 'tryLock' }],
+    ],
+  },
+  {
+    name: 'ReleaseLock',
+    intent: actions.ReleaseLock,
+    values: [[{ thread: 0 }], [{ thread: 1 }]],
+  },
+];
+
+module.exports = { instance, init, actions, getState, setState, checkerIntents };

--- a/tests/fixtures/js_sam/specs/spin-good.js
+++ b/tests/fixtures/js_sam/specs/spin-good.js
@@ -1,0 +1,114 @@
+/**
+ * Hand-written reference JS-SAM specification of the Asterinas spinlock.
+ *
+ * Follows the SysMoBench module contract:
+ *   module.exports = { instance, init, actions, getState, setState, checkerIntents }
+ *
+ * State shape:
+ *   lockHeld     boolean — whether the lock is currently held
+ *   lockHolder   number|null — thread id of the holder
+ *   threadStatus { [threadId]: 'idle' | 'trying' | 'locked' }
+ *   callType     { [threadId]: 'lock' | null } — pending blocking call, if any
+ */
+
+'use strict';
+
+const { createInstance } = require('@cognitive-fab/sam-pattern');
+
+const instance = createInstance({ instanceName: 'spin', hasAsyncActions: false });
+
+const INITIAL_STATE = {
+  lockHeld: false,
+  lockHolder: null,
+  threadStatus: { 0: 'idle', 1: 'idle' },
+  callType: { 0: null, 1: null },
+};
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const { intents } = instance({
+  initialState: clone(INITIAL_STATE),
+  component: {
+    actions: [
+      ({ thread, callType = 'lock' } = {}) => ({ __name: 'AcquireLock', acquire: { thread, callType } }),
+      ({ thread } = {}) => ({ __name: 'ReleaseLock', release: { thread } }),
+    ],
+    acceptors: [
+      (model) => ({ acquire }) => {
+        if (acquire == null) return;
+        const { thread, callType } = acquire;
+        const id = String(thread);
+        if (model.threadStatus[id] === undefined) return; // unknown thread
+        if (model.threadStatus[id] === 'locked') return; // re-entry is a no-op
+        if (!model.lockHeld) {
+          // CAS succeeds
+          model.lockHeld = true;
+          model.lockHolder = thread;
+          model.threadStatus[id] = 'locked';
+          model.callType[id] = null;
+        } else if (callType === 'tryLock') {
+          // try_lock() never spins: return to idle immediately
+          model.threadStatus[id] = 'idle';
+          model.callType[id] = null;
+        } else {
+          // lock() spins: stay in trying until the lock frees up
+          model.threadStatus[id] = 'trying';
+          model.callType[id] = 'lock';
+        }
+      },
+      (model) => ({ release }) => {
+        if (release == null) return;
+        const id = String(release.thread);
+        if (model.lockHolder !== release.thread) return; // only the holder may release
+        model.lockHeld = false;
+        model.lockHolder = null;
+        model.threadStatus[id] = 'idle';
+        model.callType[id] = null;
+      },
+    ],
+  },
+});
+
+const [acquireIntent, releaseIntent] = intents;
+
+const sanitizeReplacer = (key, value) => {
+  if (typeof key === 'string' && key.startsWith('__')) return undefined;
+  if (typeof value === 'function') return undefined;
+  return value;
+};
+
+const getState = () => JSON.parse(JSON.stringify(instance({}).state(), sanitizeReplacer));
+
+const setState = (snapshot) => {
+  instance({ initialState: clone(snapshot) });
+};
+
+const init = () => {
+  instance({}).state().clearError();
+  setState(INITIAL_STATE);
+};
+
+const actions = {
+  AcquireLock: (data = {}) => acquireIntent(data),
+  ReleaseLock: (data = {}) => releaseIntent(data),
+};
+
+const checkerIntents = [
+  {
+    name: 'AcquireLock',
+    intent: actions.AcquireLock,
+    values: [
+      [{ thread: 0, callType: 'lock' }],
+      [{ thread: 1, callType: 'lock' }],
+      [{ thread: 0, callType: 'tryLock' }],
+      [{ thread: 1, callType: 'tryLock' }],
+    ],
+  },
+  {
+    name: 'ReleaseLock',
+    intent: actions.ReleaseLock,
+    values: [[{ thread: 0 }], [{ thread: 1 }]],
+  },
+];
+
+module.exports = { instance, init, actions, getState, setState, checkerIntents };

--- a/tests/fixtures/js_sam/specs/spin-load-error.js
+++ b/tests/fixtures/js_sam/specs/spin-load-error.js
@@ -1,0 +1,5 @@
+/** Fixture: parses fine but throws at import time (Phase 1 load check). */
+
+'use strict';
+
+throw new Error('import-time failure: configuration table not found');

--- a/tests/fixtures/js_sam/specs/spin-missing-export.js
+++ b/tests/fixtures/js_sam/specs/spin-missing-export.js
@@ -1,0 +1,14 @@
+/** Fixture: loads fine but violates the module contract (no setState/checkerIntents). */
+
+'use strict';
+
+const state = { lockHeld: false };
+
+module.exports = {
+  instance: () => ({ state: () => state }),
+  init: () => {},
+  actions: { AcquireLock: () => {} },
+  getState: () => state,
+  // setState missing
+  // checkerIntents missing
+};

--- a/tests/fixtures/js_sam/specs/spin-syntax-error.js
+++ b/tests/fixtures/js_sam/specs/spin-syntax-error.js
@@ -1,0 +1,9 @@
+/** Fixture: fails the Phase 1 parse check (unbalanced brace). */
+
+'use strict';
+
+const broken = {
+  lockHeld: false,
+// missing closing brace
+
+module.exports = broken;

--- a/tests/fixtures/js_sam/specs/spin-throwing.js
+++ b/tests/fixtures/js_sam/specs/spin-throwing.js
@@ -1,0 +1,80 @@
+/**
+ * Fixture: structurally valid spec whose ReleaseLock acceptor throws on a
+ * reachable state. Phase 2 exploration must classify this as runtime_error.
+ */
+
+'use strict';
+
+const { createInstance } = require('@cognitive-fab/sam-pattern');
+
+const instance = createInstance({ instanceName: 'spin-throwing', hasAsyncActions: false });
+
+const INITIAL_STATE = {
+  lockHeld: false,
+  lockHolder: null,
+  threadStatus: { 0: 'idle', 1: 'idle' },
+};
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const { intents } = instance({
+  initialState: clone(INITIAL_STATE),
+  component: {
+    actions: [
+      ({ thread } = {}) => ({ __name: 'AcquireLock', acquire: { thread } }),
+      ({ thread } = {}) => ({ __name: 'ReleaseLock', release: { thread } }),
+    ],
+    acceptors: [
+      (model) => ({ acquire }) => {
+        if (acquire == null) return;
+        const id = String(acquire.thread);
+        if (model.threadStatus[id] === undefined || model.lockHeld) return;
+        model.lockHeld = true;
+        model.lockHolder = acquire.thread;
+        model.threadStatus[id] = 'locked';
+      },
+      (model) => ({ release }) => {
+        if (release == null) return;
+        if (model.lockHolder !== release.thread) {
+          // BUG: a release by a non-holder is a reachable state during
+          // exploration; a robust model would reject it as a no-op.
+          throw new Error('release by non-holder');
+        }
+        model.lockHeld = false;
+        model.lockHolder = null;
+        model.threadStatus[String(release.thread)] = 'idle';
+      },
+    ],
+  },
+});
+
+const [acquireIntent, releaseIntent] = intents;
+
+const sanitizeReplacer = (key, value) => {
+  if (typeof key === 'string' && key.startsWith('__')) return undefined;
+  if (typeof value === 'function') return undefined;
+  return value;
+};
+
+const getState = () => JSON.parse(JSON.stringify(instance({}).state(), sanitizeReplacer));
+
+const setState = (snapshot) => {
+  instance({ initialState: clone(snapshot) });
+};
+
+const init = () => {
+  instance({}).state().clearError();
+  setState(INITIAL_STATE);
+};
+
+const actions = {
+  AcquireLock: (data = {}) => acquireIntent(data),
+  ReleaseLock: (data = {}) => releaseIntent(data),
+};
+
+const checkerIntents = [
+  { name: 'AcquireLock', intent: actions.AcquireLock, values: [[{ thread: 0 }], [{ thread: 1 }]] },
+  { name: 'ReleaseLock', intent: actions.ReleaseLock, values: [[{ thread: 0 }], [{ thread: 1 }]] },
+];
+
+module.exports = { instance, init, actions, getState, setState, checkerIntents };

--- a/tests/fixtures/js_sam/traces/spin-events.ndjson
+++ b/tests/fixtures/js_sam/traces/spin-events.ndjson
@@ -1,0 +1,3 @@
+{"action": "AcquireLock", "data": {"thread": 0, "callType": "lock"}, "pre_state": {"lockHeld": false, "lockHolder": null, "threadStatus": {"0": "idle", "1": "idle"}, "callType": {"0": null, "1": null}}, "post_state": {"lockHeld": true, "lockHolder": 0, "threadStatus": {"0": "locked", "1": "idle"}, "callType": {"0": null, "1": null}}}
+{"action": "ReleaseLock", "data": {"thread": 0}, "pre_state": {"lockHeld": true, "lockHolder": 0, "threadStatus": {"0": "locked", "1": "idle"}, "callType": {"0": null, "1": null}}, "post_state": {"lockHeld": false, "lockHolder": null, "threadStatus": {"0": "idle", "1": "idle"}, "callType": {"0": null, "1": null}}}
+{"action": "Noise", "pre_state": {"lockHeld": false}, "post_state": {"lockHeld": false}}

--- a/tests/fixtures/js_sam/traces/spin-stream.ndjson
+++ b/tests/fixtures/js_sam/traces/spin-stream.ndjson
@@ -1,0 +1,7 @@
+{"state": {"lockHeld": false, "lockHolder": null, "threadStatus": {"0": "idle", "1": "idle"}, "callType": {"0": null, "1": null}}}
+{"action": "AcquireLock", "data": {"thread": 0, "callType": "lock"}, "state": {"lockHeld": true, "lockHolder": 0, "threadStatus": {"0": "locked", "1": "idle"}, "callType": {"0": null, "1": null}}}
+{"action": "AcquireLock", "data": {"thread": 1, "callType": "lock"}, "state": {"lockHeld": true, "lockHolder": 0, "threadStatus": {"0": "locked", "1": "trying"}, "callType": {"0": null, "1": "lock"}}}
+{"action": "ReleaseLock", "data": {"thread": 0}, "state": {"lockHeld": false, "lockHolder": null, "threadStatus": {"0": "idle", "1": "trying"}, "callType": {"0": null, "1": "lock"}}}
+{"action": "AcquireLock", "data": {"thread": 1, "callType": "lock"}, "state": {"lockHeld": true, "lockHolder": 1, "threadStatus": {"0": "idle", "1": "locked"}, "callType": {"0": null, "1": null}}}
+{"action": "AcquireLock", "data": {"thread": 0, "callType": "tryLock"}, "state": {"lockHeld": true, "lockHolder": 1, "threadStatus": {"0": "idle", "1": "locked"}, "callType": {"0": null, "1": null}}}
+{"action": "ReleaseLock", "data": {"thread": 1}, "state": {"lockHeld": false, "lockHolder": null, "threadStatus": {"0": "idle", "1": "idle"}, "callType": {"0": null, "1": null}}}

--- a/tests/test_evaluation/test_trace_loader.py
+++ b/tests/test_evaluation/test_trace_loader.py
@@ -1,0 +1,136 @@
+"""
+Tests for the language-neutral trace loader and the direct Phase 3 path in
+TransitionValidationEvaluator.
+"""
+
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tla_eval.evaluation.semantics.trace_loader import load_trace_windows
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_TRACES = PROJECT_ROOT / "tests" / "fixtures" / "js_sam" / "traces"
+
+TARGETS = ["AcquireLock", "ReleaseLock"]
+
+
+class TestTraceLoaderStreamForm:
+    def test_windows_from_consecutive_states(self, tmp_path):
+        shutil.copy(FIXTURE_TRACES / "spin-stream.ndjson", tmp_path / "t.ndjson")
+        windows = load_trace_windows("spin", traces_dir=tmp_path, target_actions=TARGETS)
+        # 7 lines: 1 seed state + 6 action records -> 6 windows
+        assert len(windows) == 6
+        action, pre, post = windows[0]
+        assert action == {"name": "AcquireLock", "data": {"thread": 0, "callType": "lock"}}
+        assert pre["lockHeld"] is False
+        assert post["lockHeld"] is True
+
+    def test_pre_state_chains_through_the_stream(self, tmp_path):
+        shutil.copy(FIXTURE_TRACES / "spin-stream.ndjson", tmp_path / "t.ndjson")
+        windows = load_trace_windows("spin", traces_dir=tmp_path, target_actions=TARGETS)
+        for i in range(1, len(windows)):
+            assert windows[i][1] == windows[i - 1][2]
+
+
+class TestTraceLoaderEventForm:
+    def test_self_contained_windows_and_filtering(self, tmp_path):
+        shutil.copy(FIXTURE_TRACES / "spin-events.ndjson", tmp_path / "t.ndjson")
+        windows = load_trace_windows("spin", traces_dir=tmp_path, target_actions=TARGETS)
+        # 3 records, one of which ("Noise") is off-target.
+        assert len(windows) == 2
+        assert [w[0]["name"] for w in windows] == ["AcquireLock", "ReleaseLock"]
+
+    def test_no_filter_keeps_everything(self, tmp_path):
+        shutil.copy(FIXTURE_TRACES / "spin-events.ndjson", tmp_path / "t.ndjson")
+        windows = load_trace_windows("spin", traces_dir=tmp_path, target_actions=[])
+        assert len(windows) == 3
+        # The Noise record carries no data payload -> plain string action.
+        assert windows[2][0] == "Noise"
+
+
+class TestTraceLoaderErrors:
+    def test_missing_folder_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="Trace folder not found"):
+            load_trace_windows("spin", traces_dir=tmp_path / "nope", target_actions=TARGETS)
+
+    def test_empty_folder_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="contains no"):
+            load_trace_windows("spin", traces_dir=tmp_path, target_actions=TARGETS)
+
+    def test_unparseable_lines_are_skipped(self, tmp_path):
+        (tmp_path / "t.ndjson").write_text(
+            'not json\n{"action": "AcquireLock", "pre_state": {}, "post_state": {}}\n',
+            encoding="utf-8",
+        )
+        windows = load_trace_windows("spin", traces_dir=tmp_path, target_actions=TARGETS)
+        assert len(windows) == 1
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="Node.js is required for the direct-path evaluator test",
+)
+class TestDirectPathEvaluator:
+    def test_direct_path_dispatches_to_backend(self, tmp_path, monkeypatch):
+        from tla_eval.evaluation.semantics import trace_loader
+        from tla_eval.evaluation.semantics.transition_validation import (
+            TransitionValidationEvaluator,
+        )
+
+        spec = PROJECT_ROOT / "tests" / "fixtures" / "js_sam" / "specs" / "spin-good.js"
+        pre = {
+            "lockHeld": False, "lockHolder": None,
+            "threadStatus": {"0": "idle", "1": "idle"},
+            "callType": {"0": None, "1": None},
+        }
+        post = {
+            "lockHeld": True, "lockHolder": 0,
+            "threadStatus": {"0": "locked", "1": "idle"},
+            "callType": {"0": None, "1": None},
+        }
+        windows = [({"name": "AcquireLock", "data": {"thread": 0, "callType": "lock"}}, pre, post)]
+        monkeypatch.setattr(trace_loader, "load_trace_windows", lambda task_name: windows)
+
+        evaluator = TransitionValidationEvaluator(
+            language="JS-SAM", workspace_root=str(tmp_path)
+        )
+        result = evaluator.evaluate(
+            generation_result=SimpleNamespace(metadata={}),
+            task_name="spin",
+            method_name="direct_call",
+            model_name="fixture",
+            spec_file_path=str(spec),
+        )
+
+        assert result.error_message is None
+        assert result.total_windows == 1
+        assert result.total_passed == 1
+        assert result.score == 1.0
+        assert result.overall_success
+        assert result.per_action_pass_rates == {"AcquireLock": 1.0}
+
+    def test_missing_traces_reported_cleanly(self, tmp_path, monkeypatch):
+        from tla_eval.evaluation.semantics.transition_validation import (
+            TransitionValidationEvaluator,
+        )
+
+        spec = PROJECT_ROOT / "tests" / "fixtures" / "js_sam" / "specs" / "spin-good.js"
+        evaluator = TransitionValidationEvaluator(
+            language="JS-SAM", workspace_root=str(tmp_path)
+        )
+        # No monkeypatch: the real spin traces_folder (data/sys_traces/spin)
+        # is not checked into the repository, so the loader must fail with an
+        # actionable message rather than a crash.
+        result = evaluator.evaluate(
+            generation_result=SimpleNamespace(metadata={}),
+            task_name="spin",
+            method_name="direct_call",
+            model_name="fixture",
+            spec_file_path=str(spec),
+        )
+        assert not result.overall_success
+        assert result.error_message
+        assert "Trace folder" in result.error_message or "traces_folder" in result.error_message

--- a/tests/test_languages/test_js_sam.py
+++ b/tests/test_languages/test_js_sam.py
@@ -1,0 +1,248 @@
+"""
+JS-SAM backend tests.
+
+Integration-style: they exercise the real Node helper (tools/js-sam/cli.mjs)
+against the fixtures in tests/fixtures/js_sam/. Skipped when Node or the
+helper's node_modules are unavailable.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tla_eval.languages import get
+from tla_eval.languages.base import InvariantTemplate
+from tla_eval.languages.js_sam import (
+    HELPER_NODE_MODULES,
+    JsSamBackend,
+    _parse_js_sam_translations,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = PROJECT_ROOT / "tests" / "fixtures" / "js_sam"
+SPECS = FIXTURES / "specs"
+
+node_required = pytest.mark.skipif(
+    shutil.which("node") is None or not HELPER_NODE_MODULES.exists(),
+    reason="Node.js or the JS-SAM helper dependencies are not installed",
+)
+
+
+@pytest.fixture()
+def backend():
+    return get("js-sam")
+
+
+class TestRegistration:
+    def test_registry_resolution(self):
+        backend = get("js-sam")
+        assert backend.name == "JS-SAM"
+        assert get("JS-SAM") is backend
+        assert get("SAM") is backend
+        assert get("jssam") is backend
+
+    def test_identity_fields(self):
+        backend = get("js-sam")
+        assert backend.fence_label == "javascript"
+        assert backend.spec_extension == ".js"
+        assert backend.config_fence_label is None
+        assert backend.supports_direct_transition_validation is True
+
+    def test_extract_artifacts_accepts_js_and_javascript_fences(self):
+        backend = get("js-sam")
+        body = "module.exports = {};"
+        for label in ("javascript", "js"):
+            artifacts = backend.extract_artifacts(f"text\n```{label}\n{body}\n```\ntail")
+            assert artifacts.spec == body
+            assert artifacts.config is None
+
+
+@node_required
+class TestCheckAvailable:
+    def test_tools_ready(self, backend):
+        assert backend.check_available() is None
+
+
+@node_required
+class TestPhase1Syntax:
+    def _validate(self, backend, fixture, tmp_path):
+        spec = (SPECS / fixture).read_text(encoding="utf-8")
+        return backend.validate_syntax(spec, None, tmp_path, timeout=60)
+
+    def test_good_spec_passes(self, backend, tmp_path):
+        outcome = self._validate(backend, "spin-good.js", tmp_path)
+        assert outcome.success, outcome.raw_output
+        assert outcome.syntax_errors == []
+        assert outcome.semantic_errors == []
+
+    def test_syntax_error_reported_as_syntax(self, backend, tmp_path):
+        outcome = self._validate(backend, "spin-syntax-error.js", tmp_path)
+        assert not outcome.success
+        assert outcome.syntax_errors
+        assert outcome.semantic_errors == []
+
+    def test_import_throw_reported_as_semantic(self, backend, tmp_path):
+        outcome = self._validate(backend, "spin-load-error.js", tmp_path)
+        assert not outcome.success
+        assert outcome.syntax_errors == []
+        assert any("failed to load" in e for e in outcome.semantic_errors)
+
+    def test_contract_violations_reported(self, backend, tmp_path):
+        outcome = self._validate(backend, "spin-missing-export.js", tmp_path)
+        assert not outcome.success
+        joined = " ".join(outcome.semantic_errors)
+        assert "setState" in joined
+        assert "checkerIntents" in joined
+
+
+@node_required
+class TestPhase2ModelCheck:
+    def test_good_spec_explores_cleanly(self, backend, tmp_path):
+        outcome = backend.run_model_checker(SPECS / "spin-good.js", None, tmp_path, timeout=300)
+        assert outcome.success, outcome.error_message
+        assert outcome.classification is None
+
+    def test_throwing_acceptor_is_runtime_error(self, backend, tmp_path):
+        outcome = backend.run_model_checker(SPECS / "spin-throwing.js", None, tmp_path, timeout=300)
+        assert not outcome.success
+        assert outcome.classification == "runtime_error"
+        assert "release by non-holder" in outcome.error_message
+
+
+@node_required
+class TestPhase3Transitions:
+    PRE_FREE = {
+        "lockHeld": False, "lockHolder": None,
+        "threadStatus": {"0": "idle", "1": "idle"},
+        "callType": {"0": None, "1": None},
+    }
+    POST_HELD_0 = {
+        "lockHeld": True, "lockHolder": 0,
+        "threadStatus": {"0": "locked", "1": "idle"},
+        "callType": {"0": None, "1": None},
+    }
+
+    def _windows(self):
+        return [
+            (
+                {"name": "AcquireLock", "data": {"thread": 0, "callType": "lock"}},
+                self.PRE_FREE,
+                self.POST_HELD_0,
+            ),
+            (
+                {"name": "ReleaseLock", "data": {"thread": 0}},
+                self.POST_HELD_0,
+                self.PRE_FREE,
+            ),
+        ]
+
+    def test_good_spec_passes_all_windows(self, backend, tmp_path):
+        outcome = backend.validate_transitions(
+            SPECS / "spin-good.js", self._windows(), tmp_path, timeout=120
+        )
+        assert outcome.error_message is None
+        assert outcome.total_windows == 2
+        assert outcome.total_passed == 2
+        assert outcome.per_action_pass_rates == {"AcquireLock": 1.0, "ReleaseLock": 1.0}
+
+    def test_buggy_release_fails_only_release_windows(self, backend, tmp_path):
+        outcome = backend.validate_transitions(
+            SPECS / "spin-bad-release.js", self._windows(), tmp_path, timeout=120
+        )
+        assert outcome.error_message is None
+        assert outcome.per_action_pass_rates["AcquireLock"] == 1.0
+        assert outcome.per_action_pass_rates["ReleaseLock"] == 0.0
+        failures = json.loads((tmp_path / "transition_failures.json").read_text(encoding="utf-8"))
+        assert any(f["action"] == "ReleaseLock" for f in failures)
+
+    def test_unknown_action_counts_as_failed_window(self, backend, tmp_path):
+        windows = [("NotAnAction", self.PRE_FREE, self.PRE_FREE)]
+        outcome = backend.validate_transitions(
+            SPECS / "spin-good.js", windows, tmp_path, timeout=120
+        )
+        assert outcome.total_windows == 1
+        assert outcome.total_passed == 0
+        assert outcome.per_action_pass_rates["NotAnAction"] == 0.0
+
+    def test_empty_windows_is_an_error(self, backend, tmp_path):
+        outcome = backend.validate_transitions(SPECS / "spin-good.js", [], tmp_path, timeout=120)
+        assert outcome.error_message
+
+
+@node_required
+class TestPhase4Invariants:
+    def _templates(self):
+        return [
+            InvariantTemplate(
+                name="MutualExclusion", type="safety",
+                natural_language="At most one thread holds the lock",
+                formal_description="", example="",
+            ),
+            InvariantTemplate(
+                name="AlwaysFree", type="safety",
+                natural_language="The lock is never held (deliberately false)",
+                formal_description="", example="",
+            ),
+        ]
+
+    def test_check_invariants_pass_and_fail(self, backend, tmp_path):
+        translated = {
+            "MutualExclusion":
+                "(state) => Object.values(state.threadStatus || {})"
+                ".filter((s) => s === 'locked').length <= 1",
+            "AlwaysFree": "(state) => state.lockHeld === false",
+        }
+        outcome = backend.check_invariants(
+            SPECS / "spin-good.js", None, self._templates(), translated, tmp_path, timeout=300
+        )
+        by_name = {c.name: c for c in outcome.cases}
+        assert by_name["MutualExclusion"].success, by_name["MutualExclusion"].error_message
+        assert not by_name["AlwaysFree"].success
+        assert by_name["AlwaysFree"].metadata.get("counterexample")
+
+    def test_missing_translation_is_a_failure_case(self, backend, tmp_path):
+        outcome = backend.check_invariants(
+            SPECS / "spin-good.js", None, self._templates()[:1], {}, tmp_path, timeout=120
+        )
+        assert len(outcome.cases) == 1
+        assert not outcome.cases[0].success
+        assert "No translated invariant" in outcome.cases[0].error_message
+
+
+class TestTranslationParsing:
+    def _templates(self):
+        return [
+            InvariantTemplate(
+                name="MutualExclusion", type="safety",
+                natural_language="", formal_description="", example="",
+            ),
+        ]
+
+    def test_parses_plain_json(self):
+        text = json.dumps({
+            "invariants": [{"name": "MutualExclusion", "predicate": "(state) => true"}]
+        })
+        out = _parse_js_sam_translations(text, self._templates())
+        assert out == {"MutualExclusion": "(state) => true"}
+
+    def test_parses_fenced_json_and_case_insensitive_names(self):
+        text = '```json\n{"invariants": [{"name": "mutualexclusion", "predicate": "(s) => true"}]}\n```'
+        out = _parse_js_sam_translations(text, self._templates())
+        assert out == {"MutualExclusion": "(s) => true"}
+
+    def test_rejects_garbage(self):
+        assert _parse_js_sam_translations("not json", self._templates()) == {}
+        assert _parse_js_sam_translations('{"foo": 1}', self._templates()) == {}
+
+    def test_unknown_translator_unsupported(self):
+        backend = JsSamBackend()
+        # An explicit unknown model name is forwarded to the model registry,
+        # which fails as "not configured" — exercised via the error return.
+        translated, error = backend.translate_invariants(
+            self._templates(), "module.exports = {}", "spin",
+            translator="definitely-not-a-model",
+        )
+        assert translated == {}
+        assert error

--- a/tla_eval/evaluation/semantics/trace_loader.py
+++ b/tla_eval/evaluation/semantics/trace_loader.py
@@ -1,0 +1,159 @@
+"""
+Language-neutral NDJSON trace loading + windowing for the direct Phase 3 path.
+
+Backends that set `supports_direct_transition_validation = True` receive an
+iterable of `(action, pre_state, post_state)` windows (see
+languages/base.py:validate_transitions). This module produces those windows
+from the task's captured system traces.
+
+Two NDJSON record shapes are accepted, and may be mixed within a file:
+
+  Event form — one self-contained window per line:
+    {"action": "AcquireLock", "data": {...}, "pre_state": {...}, "post_state": {...}}
+
+  Stream form — a state snapshot per line; consecutive lines form windows:
+    {"state": {...}}                                       # seeds the stream
+    {"action": "AcquireLock", "data": {...}, "state": {...}}   # post-state of the action
+
+`action` in a yielded window is the plain action name when the record has no
+`data` payload, or `{"name": ..., "data": ...}` when it does. Windows whose
+action is not in the task's `tv.target_actions` are skipped (the stream still
+advances through them).
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+TRACE_GLOBS = ("*.ndjson", "*.jsonl")
+
+Action = Union[str, Dict[str, Any]]
+Window = Tuple[Action, Dict[str, Any], Dict[str, Any]]
+
+
+def _load_task_config(task_name: str) -> Dict[str, Any]:
+    from ...tasks.loader import get_task_loader
+
+    task_yaml = Path(get_task_loader().tasks_dir) / task_name / "task.yaml"
+    if not task_yaml.exists():
+        raise FileNotFoundError(f"task.yaml not found for task '{task_name}': {task_yaml}")
+    return yaml.safe_load(task_yaml.read_text(encoding="utf-8")) or {}
+
+
+def _make_action(name: str, data: Optional[Dict[str, Any]]) -> Action:
+    return {"name": name, "data": data} if data else name
+
+
+def load_trace_windows(
+    task_name: str,
+    traces_dir: Optional[Path] = None,
+    target_actions: Optional[List[str]] = None,
+) -> List[Window]:
+    """
+    Load all trace windows for a task.
+
+    `traces_dir` and `target_actions` override the task.yaml values
+    (`traces_folder` and `tv.target_actions`) when given — mainly for tests.
+
+    Raises FileNotFoundError when the trace folder is missing or holds no
+    trace files: captured traces are produced by the task's instrumentation
+    harness (task.yaml > tv.harness) and are not checked into the repository.
+    """
+    if traces_dir is None or target_actions is None:
+        config = _load_task_config(task_name)
+        if traces_dir is None:
+            folder = config.get("traces_folder")
+            if not folder:
+                raise FileNotFoundError(
+                    f"Task '{task_name}' declares no traces_folder in task.yaml."
+                )
+            traces_dir = Path(folder)
+        if target_actions is None:
+            target_actions = (config.get("tv") or {}).get("target_actions") or []
+
+    traces_dir = Path(traces_dir)
+    if not traces_dir.is_absolute():
+        from ...tasks.loader import get_task_loader
+
+        # task.yaml paths are repo-root-relative; resolve against the same
+        # root the task loader uses (its tasks_dir is <root>/tla_eval/tasks).
+        root = Path(get_task_loader().tasks_dir).resolve().parent.parent
+        traces_dir = root / traces_dir
+
+    if not traces_dir.exists():
+        raise FileNotFoundError(
+            f"Trace folder not found: {traces_dir}. Captured traces are generated "
+            f"by the task's instrumentation harness (see task.yaml > tv.harness) "
+            f"and are not checked into the repository."
+        )
+
+    trace_files: List[Path] = []
+    for pattern in TRACE_GLOBS:
+        trace_files.extend(sorted(traces_dir.glob(pattern)))
+    if not trace_files:
+        raise FileNotFoundError(f"Trace folder {traces_dir} contains no {TRACE_GLOBS} files.")
+
+    windows: List[Window] = []
+    wanted = set(target_actions or [])
+    skipped = 0
+
+    for trace_file in trace_files:
+        prev_state: Optional[Dict[str, Any]] = None
+        with open(trace_file, encoding="utf-8") as f:
+            for line_number, line in enumerate(f, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as e:
+                    logger.warning("%s:%d unparseable trace line: %s", trace_file, line_number, e)
+                    continue
+                if not isinstance(record, dict):
+                    continue
+
+                action_name = record.get("action")
+
+                if "pre_state" in record and "post_state" in record:
+                    # Event form: a self-contained window.
+                    if action_name and (not wanted or action_name in wanted):
+                        windows.append(
+                            (
+                                _make_action(action_name, record.get("data")),
+                                record["pre_state"],
+                                record["post_state"],
+                            )
+                        )
+                    elif action_name:
+                        skipped += 1
+                    prev_state = record["post_state"]
+                elif "state" in record:
+                    # Stream form: window from the previous snapshot to this one.
+                    if action_name and prev_state is not None:
+                        if not wanted or action_name in wanted:
+                            windows.append(
+                                (
+                                    _make_action(action_name, record.get("data")),
+                                    prev_state,
+                                    record["state"],
+                                )
+                            )
+                        else:
+                            skipped += 1
+                    prev_state = record["state"]
+                else:
+                    logger.warning(
+                        "%s:%d trace record has neither pre/post_state nor state; skipped",
+                        trace_file, line_number,
+                    )
+
+    logger.info(
+        "Loaded %d trace window(s) for %s from %d file(s) in %s (%d off-target skipped)",
+        len(windows), task_name, len(trace_files), traces_dir, skipped,
+    )
+    return windows

--- a/tla_eval/evaluation/semantics/transition_validation.py
+++ b/tla_eval/evaluation/semantics/transition_validation.py
@@ -84,14 +84,10 @@ class TransitionValidationEvaluator(BaseEvaluator):
         spec_dir = spec_path.parent
 
         if self.backend.supports_direct_transition_validation:
-            # Direct path: hand control to the backend. Trace loading + windowing
-            # is the backend's responsibility (it knows the language semantics).
-            result.error_message = (
-                f"Direct transition validation for {self.language} is declared "
-                "supported but the evaluator wrapper for that path is not yet implemented."
-            )
-            logger.error(result.error_message)
-            return result
+            # Direct path: the evaluator loads and windows the traces
+            # (language-neutral, see trace_loader.py); the backend validates
+            # each (pre, action, post) window against the spec.
+            return self._evaluate_direct(result, task_name, spec_path)
 
         logger.warning(
             "Launching transition validation for %s (%s) — agent path. "
@@ -208,6 +204,64 @@ class TransitionValidationEvaluator(BaseEvaluator):
         result.overall_success = result.total_windows > 0 and result.score > 0
         logger.info(
             f"Transition validation: {result.total_passed}/{result.total_windows} "
+            f"({result.score:.1%}) across {len(result.per_action_pass_rates)} actions"
+        )
+        return result
+
+    def _evaluate_direct(self,
+                         result: TransitionValidationResult,
+                         task_name: str,
+                         spec_path: Path) -> TransitionValidationResult:
+        """
+        Direct Phase 3: load NDJSON trace windows and hand them to the
+        backend's validate_transitions. Runs in seconds and needs no agent.
+        """
+        from .trace_loader import load_trace_windows
+
+        workspace = self.workspace_root / f"direct_{task_name}_{self.language.lower().replace('+', '')}"
+        workspace.mkdir(parents=True, exist_ok=True)
+        result.workspace_dir = str(workspace)
+
+        start = time.time()
+        try:
+            windows = load_trace_windows(task_name)
+        except FileNotFoundError as e:
+            result.elapsed_seconds = time.time() - start
+            result.error_message = str(e)
+            logger.error(result.error_message)
+            return result
+        except Exception as e:
+            result.elapsed_seconds = time.time() - start
+            result.error_message = f"Trace loading failed for {task_name}: {e}"
+            logger.error(result.error_message)
+            return result
+
+        try:
+            outcome = self.backend.validate_transitions(
+                spec_path, windows, workspace, self.tv_timeout,
+            )
+        except Exception as e:
+            result.elapsed_seconds = time.time() - start
+            result.error_message = f"Direct transition validation failed: {e}"
+            logger.error(result.error_message)
+            return result
+        result.elapsed_seconds = time.time() - start
+
+        if outcome.error_message:
+            result.error_message = outcome.error_message
+            logger.error(result.error_message)
+            return result
+
+        result.total_passed = outcome.total_passed
+        result.total_windows = outcome.total_windows
+        result.per_action_pass_rates = dict(outcome.per_action_pass_rates)
+        if result.total_windows > 0:
+            result.score = result.total_passed / result.total_windows
+
+        # Same success policy as the agent path (see above).
+        result.overall_success = result.total_windows > 0 and result.score > 0
+        logger.info(
+            f"Transition validation (direct): {result.total_passed}/{result.total_windows} "
             f"({result.score:.1%}) across {len(result.per_action_pass_rates)} actions"
         )
         return result

--- a/tla_eval/languages/js_sam.py
+++ b/tla_eval/languages/js_sam.py
@@ -1,0 +1,474 @@
+"""
+JS-SAM language backend.
+
+Evaluates specifications written as executable JavaScript modules following
+the SAM pattern (https://sam.js.org), built on @cognitive-fab/sam-pattern and
+@cognitive-fab/sam-fsm. SAM is grounded in TLA+ semantics — actions present
+proposals, the model accepts them, state is a pure function of the model —
+but the artifact is a runnable .js module rather than formal-spec source.
+
+The Python side shells out to a small Node helper
+(tools/js-sam/cli.mjs) with JSON-in / JSON-out — the same shape as the Alloy
+(Java helper) and PAT (mono console) backends.
+
+This is the first backend to set `supports_direct_transition_validation`:
+SAM is literally `model.present(action(data))`, so Phase 3 trace replay
+reduces to `setState(pre); actions[name](data); diff(getState(), post)` with
+no agent orchestration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+from string import Template
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base import InvariantTemplate, LanguageBackend, SpecArtifacts
+from .registry import register
+from .result_types import (
+    InvariantCaseResult,
+    InvariantOutcome,
+    ModelCheckOutcome,
+    SyntaxOutcome,
+    TransitionOutcome,
+)
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+HELPER_DIR = PROJECT_ROOT / "tools" / "js-sam"
+HELPER_CLI = HELPER_DIR / "cli.mjs"
+HELPER_NODE_MODULES = HELPER_DIR / "node_modules"
+
+MIN_NODE_MAJOR = 20
+
+# Bench-wide exploration depth for the sam-pattern behavior explorer
+# (Phases 2 and 4). Deliberately a single constant rather than per-task
+# config: revisit when a second task lands (spec Open Question 3).
+DEFAULT_DEPTH_MAX = 6
+
+
+def _helper_env() -> Dict[str, str]:
+    """Make the helper's node_modules resolvable from specs in any work dir."""
+    env = dict(os.environ)
+    node_path = str(HELPER_NODE_MODULES)
+    existing = env.get("NODE_PATH")
+    env["NODE_PATH"] = f"{node_path}{os.pathsep}{existing}" if existing else node_path
+    return env
+
+
+def _run_helper(
+    subcommand: str, request: Dict[str, Any], timeout: int
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """
+    Invoke one helper subcommand. Returns (response, error_message); exactly
+    one of the two is None. Helper-level failures (crash, bad JSON, ok=False)
+    are tooling errors, not spec failures.
+    """
+    cmd = ["node", str(HELPER_CLI), subcommand]
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=json.dumps(request),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=_helper_env(),
+            cwd=str(PROJECT_ROOT),
+        )
+    except subprocess.TimeoutExpired:
+        return None, f"JS-SAM helper timed out after {timeout}s ({subcommand})"
+    except FileNotFoundError as e:
+        return None, f"Cannot run node: {e}"
+
+    try:
+        response = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        tail = ((proc.stderr or "") + (proc.stdout or ""))[-1500:]
+        return None, (
+            f"JS-SAM helper produced no JSON (exit {proc.returncode}, {subcommand}). "
+            f"Output tail:\n{tail}"
+        )
+
+    if not response.get("ok", False):
+        return None, f"JS-SAM helper error ({subcommand}): {response.get('error', 'unknown')}"
+    return response, None
+
+
+def _format_js_templates_for_prompt(templates: List[InvariantTemplate]) -> str:
+    out = []
+    for t in templates:
+        out.append(
+            f"""
+### {t.name} ({t.type.upper()})
+**Description**: {t.natural_language}
+
+**Formal**: {t.formal_description}
+
+**JavaScript Example** (illustrative state shape — adapt to the actual spec):
+```javascript
+{t.example.strip()}
+```
+"""
+        )
+    return "\n".join(out)
+
+
+def _parse_js_sam_translations(
+    generated_text: str, templates: List[InvariantTemplate]
+) -> Dict[str, str]:
+    """
+    Parse {"invariants": [{"name": ..., "predicate": "(state) => ..."}]}
+    out of a model response, tolerating a markdown fence around the JSON.
+    """
+    out: Dict[str, str] = {}
+    clean = generated_text.strip()
+    fence = re.match(r"^```(?:json)?\s*\n(.*)\n```$", clean, re.DOTALL)
+    if fence:
+        clean = fence.group(1)
+
+    try:
+        data = json.loads(clean)
+    except json.JSONDecodeError as e:
+        logger.error(f"JS-SAM translator JSON parse failed: {e}")
+        return out
+
+    if not (isinstance(data, dict) and isinstance(data.get("invariants"), list)):
+        logger.error(f"Unexpected JS-SAM translation JSON structure: {data}")
+        return out
+
+    by_name = {t.name.lower(): t.name for t in templates}
+    for entry in data["invariants"]:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name", "")).strip()
+        predicate = entry.get("predicate")
+        if not name or not isinstance(predicate, str) or not predicate.strip():
+            continue
+        canonical = by_name.get(name.lower())
+        if canonical:
+            out[canonical] = predicate.strip()
+    return out
+
+
+class JsSamBackend(LanguageBackend):
+    name = "JS-SAM"
+    aliases = ("js-sam", "jssam", "sam", "javascript-sam")
+    fence_label = "javascript"
+    config_fence_label = None
+    spec_extension = ".js"
+    config_extension = None
+
+    def check_available(self) -> Optional[str]:
+        try:
+            r = subprocess.run(["node", "--version"], capture_output=True, text=True, timeout=10)
+        except Exception as e:
+            return f"Node.js not available ({e}). Install Node >= {MIN_NODE_MAJOR} LTS."
+        if r.returncode != 0:
+            return "Node.js not available; `node --version` failed."
+        version = r.stdout.strip()
+        match = re.match(r"v(\d+)\.", version)
+        if not match or int(match.group(1)) < MIN_NODE_MAJOR:
+            return f"Node {version} found but JS-SAM requires Node >= {MIN_NODE_MAJOR}."
+        if not HELPER_CLI.exists():
+            return f"JS-SAM helper not found at {HELPER_CLI}."
+        if not HELPER_NODE_MODULES.exists():
+            return (
+                f"JS-SAM helper dependencies missing. "
+                f"Run: npm install --prefix {HELPER_DIR}"
+            )
+        response, error = _run_helper("ping", {}, timeout=30)
+        if error:
+            return error
+        logger.debug(
+            "JS-SAM helper ready (node %s, sam-pattern %s)",
+            response.get("node"), response.get("samPattern"),
+        )
+        return None
+
+    def extract_artifacts(self, raw_text: str) -> SpecArtifacts:
+        """Accept both ```javascript and ```js fences (models emit either)."""
+        spec_pattern = re.compile(
+            r"```\s*(?:javascript|js)\s*\n(.*?)\n```",
+            re.DOTALL | re.IGNORECASE,
+        )
+        spec_match = spec_pattern.search(raw_text)
+        spec = spec_match.group(1) if spec_match else raw_text
+        return SpecArtifacts(spec=spec, config=None)
+
+    # ---- Phase 1 --------------------------------------------------------
+
+    def validate_syntax(
+        self,
+        spec: str,
+        config: Optional[str],
+        work_dir: Path,
+        timeout: int,
+        spec_filename: Optional[str] = None,
+    ) -> SyntaxOutcome:
+        work_dir.mkdir(parents=True, exist_ok=True)
+        spec_file = work_dir / (spec_filename or "_validate_input.js")
+        spec_file.write_text(spec, encoding="utf-8")
+
+        start = time.time()
+        try:
+            # Target-action enforcement happens in Phase 3 (the evaluator API
+            # doesn't expose the task here); Phase 1 checks parse + load +
+            # the module contract shape.
+            response, error = _run_helper(
+                "validate", {"specPath": str(spec_file.resolve())}, timeout
+            )
+        finally:
+            if spec_filename is None:
+                try:
+                    spec_file.unlink()
+                except FileNotFoundError:
+                    pass
+
+        elapsed = time.time() - start
+        if error:
+            return SyntaxOutcome(
+                success=False,
+                syntax_errors=[error],
+                raw_output=error,
+                elapsed_seconds=elapsed,
+            )
+        return SyntaxOutcome(
+            success=bool(response.get("success")),
+            syntax_errors=list(response.get("syntaxErrors", [])),
+            semantic_errors=list(response.get("semanticErrors", [])),
+            raw_output=json.dumps(response, indent=2),
+            elapsed_seconds=elapsed,
+        )
+
+    # ---- Phase 2 --------------------------------------------------------
+
+    def run_model_checker(
+        self,
+        spec_path: Path,
+        config_path: Optional[Path],
+        work_dir: Path,
+        timeout: int,
+    ) -> ModelCheckOutcome:
+        start = time.time()
+        response, error = _run_helper(
+            "check",
+            {"specPath": str(spec_path.resolve()), "depthMax": DEFAULT_DEPTH_MAX},
+            timeout,
+        )
+        elapsed = time.time() - start
+        if error:
+            classification = "timeout" if "timed out" in error else None
+            return ModelCheckOutcome(
+                success=False,
+                error_message=error,
+                elapsed_seconds=elapsed,
+                classification=classification,
+            )
+        errors = response.get("errors", [])
+        return ModelCheckOutcome(
+            success=bool(response.get("success")),
+            raw_output=json.dumps(response, indent=2),
+            elapsed_seconds=elapsed,
+            error_message="; ".join(errors) if errors else None,
+            classification=response.get("classification"),
+        )
+
+    # ---- Phase 3 (direct path) ------------------------------------------
+
+    supports_direct_transition_validation = True
+
+    def validate_transitions(
+        self,
+        spec_path: Path,
+        trace_windows,
+        work_dir: Path,
+        timeout: int,
+    ) -> TransitionOutcome:
+        windows = []
+        for window in trace_windows:
+            action, pre_state, post_state = window
+            if isinstance(action, dict):
+                name = action.get("name")
+                data = action.get("data") or {}
+            else:
+                name = action
+                data = {}
+            windows.append(
+                {"action": name, "data": data, "preState": pre_state, "postState": post_state}
+            )
+
+        if not windows:
+            return TransitionOutcome(error_message="No trace windows to validate.")
+
+        response, error = _run_helper(
+            "transitions", {"specPath": str(spec_path.resolve()), "windows": windows}, timeout
+        )
+        if error:
+            return TransitionOutcome(error_message=error)
+        if not response.get("success", False):
+            return TransitionOutcome(error_message=response.get("error", "unknown helper failure"))
+
+        work_dir.mkdir(parents=True, exist_ok=True)
+        failures = response.get("failures", [])
+        if failures:
+            (work_dir / "transition_failures.json").write_text(
+                json.dumps(failures, indent=2), encoding="utf-8"
+            )
+
+        per_action = response.get("perAction", {})
+        return TransitionOutcome(
+            per_action_pass_rates={name: stats.get("rate", 0.0) for name, stats in per_action.items()},
+            total_passed=int(response.get("totalPassed", 0)),
+            total_windows=int(response.get("totalWindows", 0)),
+        )
+
+    # ---- Phase 4 --------------------------------------------------------
+
+    def invariant_template_dirname(self) -> str:
+        return "js_sam_invariant_templates"
+
+    def invariant_example_field(self) -> str:
+        return "javascript_example"
+
+    def translate_invariants(
+        self,
+        templates: List[InvariantTemplate],
+        spec: str,
+        task_name: str,
+        translator: str = "claude-code",
+        agent_timeout: Optional[int] = None,
+    ) -> Tuple[Dict[str, str], Optional[str]]:
+        # No agent-translator exists for JS-SAM — same policy as Alloy/PAT,
+        # which remap the generic agent defaults to a direct API call
+        # (spec Open Question 4 tracks sharing real agent infrastructure).
+        if translator in ("claude-code", "codex", "claude"):
+            model_name = "claude"
+        else:
+            model_name = translator
+
+        from ..config import get_configured_model
+        from ..models.base import GenerationConfig
+        from ..tasks.loader import get_task_loader
+
+        task_loader = get_task_loader()
+        prompt_file = (
+            task_loader.tasks_dir / task_name / "prompts" / "js-sam"
+            / "phase3_invariant_implementation.txt"
+        )
+        if not prompt_file.exists():
+            return {}, f"JS-SAM invariant prompt not found: {prompt_file}"
+
+        try:
+            template_text = prompt_file.read_text(encoding="utf-8")
+            prompt = Template(template_text).substitute(
+                javascript_specification=spec,
+                invariant_templates=_format_js_templates_for_prompt(templates),
+            )
+        except Exception as e:
+            return {}, f"JS-SAM prompt format failed: {e}"
+
+        try:
+            model = get_configured_model(model_name)
+        except Exception as e:
+            return {}, f"JS-SAM translator model '{model_name}' not configured: {e}"
+
+        result = model.generate_direct(prompt, GenerationConfig(use_json_mode=True))
+        if not result.success:
+            return {}, result.error_message
+        return _parse_js_sam_translations(result.generated_text, templates), None
+
+    def check_invariants(
+        self,
+        spec_path: Path,
+        config_path: Optional[Path],
+        templates: List[InvariantTemplate],
+        translated: Dict[str, str],
+        work_dir: Path,
+        timeout: int,
+    ) -> InvariantOutcome:
+        outcome = InvariantOutcome()
+
+        requested = [
+            {"name": t.name, "predicate": translated[t.name]}
+            for t in templates
+            if t.name in translated
+        ]
+
+        results_by_name: Dict[str, Dict[str, Any]] = {}
+        helper_error: Optional[str] = None
+        if requested:
+            response, error = _run_helper(
+                "invariants",
+                {
+                    "specPath": str(spec_path.resolve()),
+                    "invariants": requested,
+                    "depthMax": DEFAULT_DEPTH_MAX,
+                },
+                timeout,
+            )
+            if error:
+                helper_error = error
+            elif not response.get("success", False):
+                helper_error = response.get("error", "unknown helper failure")
+            else:
+                results_by_name = {r["name"]: r for r in response.get("results", [])}
+
+        for template in templates:
+            name = template.name
+            trans = translated.get(name)
+            if trans is None:
+                outcome.cases.append(
+                    InvariantCaseResult(
+                        name=name, success=False,
+                        error_message="No translated invariant produced for this template.",
+                    )
+                )
+                continue
+            if helper_error:
+                outcome.cases.append(
+                    InvariantCaseResult(
+                        name=name, success=False, translated=trans,
+                        error_message=helper_error,
+                    )
+                )
+                continue
+
+            r = results_by_name.get(name)
+            if r is None:
+                outcome.cases.append(
+                    InvariantCaseResult(
+                        name=name, success=False, translated=trans,
+                        error_message="Helper returned no result for this invariant.",
+                    )
+                )
+                continue
+
+            metadata: Dict[str, Any] = {}
+            if r.get("counterexample"):
+                metadata["counterexample"] = r["counterexample"]
+            if r.get("stepsExplored") is not None:
+                metadata["steps_explored"] = r["stepsExplored"]
+
+            outcome.cases.append(
+                InvariantCaseResult(
+                    name=name,
+                    success=bool(r.get("success")),
+                    translated=trans,
+                    raw_output=json.dumps(r, indent=2),
+                    elapsed_seconds=float(r.get("elapsedMs", 0)) / 1000.0,
+                    error_message=r.get("error"),
+                    metadata=metadata,
+                )
+            )
+
+        return outcome
+
+
+register(JsSamBackend())

--- a/tla_eval/languages/js_sam.py
+++ b/tla_eval/languages/js_sam.py
@@ -7,9 +7,18 @@ the SAM pattern (https://sam.js.org), built on @cognitive-fab/sam-pattern and
 proposals, the model accepts them, state is a pure function of the model —
 but the artifact is a runnable .js module rather than formal-spec source.
 
-The Python side shells out to a small Node helper
-(tools/js-sam/cli.mjs) with JSON-in / JSON-out — the same shape as the Alloy
-(Java helper) and PAT (mono console) backends.
+The Python side runs a small Node helper (tools/js-sam/cli.mjs) with
+JSON-in / JSON-out — the same shape as the Alloy (Java helper) and PAT (mono
+console) backends.
+
+SECURITY: unlike TLA+/Alloy/PAT, whose artifacts are restricted modelling
+languages, a SAM spec is executable JavaScript that this helper loads via
+require() and whose invariant predicates it eval()s. Model-generated code is
+therefore untrusted native code. Every helper invocation runs inside a
+throwaway Docker container (see _run_helper): no network (--network none),
+read-only rootfs with the spec mounted read-only, a non-root user, and
+CPU / memory / PID limits. The container is the trust boundary; the host is
+never exposed to model-generated code.
 
 This is the first backend to set `supports_direct_transition_validation`:
 SAM is literally `model.present(action(data))`, so Phase 3 trace replay
@@ -48,30 +57,108 @@ HELPER_NODE_MODULES = HELPER_DIR / "node_modules"
 
 MIN_NODE_MAJOR = 20
 
+# Model-generated SAM specs are executable JavaScript, so the helper runs
+# inside a locked-down Docker container rather than directly on the host.
+# Docker is already a bench-wide dependency (the trace harnesses use it).
+DOCKER_IMAGE = "node:20-slim"
+_SANDBOX_MEMORY = "4g"
+_SANDBOX_CPUS = "2"
+_SANDBOX_PIDS = "256"
+
 # Bench-wide exploration depth for the sam-pattern behavior explorer
 # (Phases 2 and 4). Deliberately a single constant rather than per-task
 # config: revisit when a second task lands (spec Open Question 3).
 DEFAULT_DEPTH_MAX = 6
 
 
-def _helper_env() -> Dict[str, str]:
-    """Make the helper's node_modules resolvable from specs in any work dir."""
-    env = dict(os.environ)
-    node_path = str(HELPER_NODE_MODULES)
-    existing = env.get("NODE_PATH")
-    env["NODE_PATH"] = f"{node_path}{os.pathsep}{existing}" if existing else node_path
-    return env
+def _docker_available() -> Optional[str]:
+    """Return an error string if the Docker daemon can't be reached, else None."""
+    try:
+        r = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True, text=True, timeout=20,
+        )
+    except FileNotFoundError:
+        return (
+            "Docker not found in PATH. JS-SAM runs model-generated JavaScript "
+            "inside a sandboxed container and requires Docker."
+        )
+    except subprocess.TimeoutExpired:
+        return "Docker daemon did not respond within 20s."
+    if r.returncode != 0:
+        return f"Docker daemon not reachable: {(r.stderr or r.stdout).strip()[:200]}"
+    return None
+
+
+def _image_present() -> bool:
+    try:
+        r = subprocess.run(
+            ["docker", "image", "inspect", DOCKER_IMAGE],
+            capture_output=True, text=True, timeout=20,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _force_remove_container(name: str) -> None:
+    try:
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True, timeout=20)
+    except Exception:
+        pass
+
+
+# Monotonic-ish suffix so concurrent/sequential helper calls get distinct
+# container names (used for forced cleanup on timeout).
+_helper_call_counter = 0
 
 
 def _run_helper(
     subcommand: str, request: Dict[str, Any], timeout: int
 ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
     """
-    Invoke one helper subcommand. Returns (response, error_message); exactly
-    one of the two is None. Helper-level failures (crash, bad JSON, ok=False)
-    are tooling errors, not spec failures.
+    Invoke one helper subcommand inside a locked-down Docker container.
+    Returns (response, error_message); exactly one of the two is None.
+    Helper-level failures (crash, bad JSON, ok=False) are tooling errors,
+    not spec failures.
+
+    The container is the trust boundary for model-generated JavaScript:
+      --network none      no egress
+      --read-only         immutable rootfs; only --tmpfs /tmp is writable
+      --user <uid:gid>    non-root, no privileges
+      ro bind mounts      the helper and the single spec file, read-only
+      memory/cpu/pid caps bound a runaway or malicious spec
     """
-    cmd = ["node", str(HELPER_CLI), subcommand]
+    global _helper_call_counter
+    _helper_call_counter += 1
+    container_name = f"sysmobench-jssam-{os.getpid()}-{_helper_call_counter}"
+
+    # The helper (cli.mjs + node_modules) and, for spec-bound subcommands, the
+    # single generated spec file. The helper only reads these; all output is
+    # JSON on stdout. cli.mjs resolves node_modules from its own location, so
+    # mounting HELPER_DIR at the same path keeps that working in-container.
+    mounts = ["-v", f"{HELPER_DIR}:{HELPER_DIR}:ro"]
+    spec_path = request.get("specPath")
+    if spec_path:
+        sp = Path(spec_path).resolve()
+        mounts += ["-v", f"{sp}:{sp}:ro"]
+
+    cmd = [
+        "docker", "run", "--rm", "-i",
+        "--name", container_name,
+        "--network", "none",
+        "--user", f"{os.getuid()}:{os.getgid()}",
+        "--read-only",
+        "--tmpfs", "/tmp",
+        "-e", "HOME=/tmp",
+        "--memory", _SANDBOX_MEMORY,
+        "--cpus", _SANDBOX_CPUS,
+        "--pids-limit", _SANDBOX_PIDS,
+        *mounts,
+        "-w", str(HELPER_DIR),
+        DOCKER_IMAGE,
+        "node", str(HELPER_CLI), subcommand,
+    ]
     try:
         proc = subprocess.run(
             cmd,
@@ -79,13 +166,13 @@ def _run_helper(
             capture_output=True,
             text=True,
             timeout=timeout,
-            env=_helper_env(),
-            cwd=str(PROJECT_ROOT),
         )
     except subprocess.TimeoutExpired:
+        # The docker client was killed, but --rm may not fire — remove explicitly.
+        _force_remove_container(container_name)
         return None, f"JS-SAM helper timed out after {timeout}s ({subcommand})"
     except FileNotFoundError as e:
-        return None, f"Cannot run node: {e}"
+        return None, f"Cannot run docker: {e}"
 
     try:
         response = json.loads(proc.stdout)
@@ -166,29 +253,35 @@ class JsSamBackend(LanguageBackend):
     config_extension = None
 
     def check_available(self) -> Optional[str]:
-        try:
-            r = subprocess.run(["node", "--version"], capture_output=True, text=True, timeout=10)
-        except Exception as e:
-            return f"Node.js not available ({e}). Install Node >= {MIN_NODE_MAJOR} LTS."
-        if r.returncode != 0:
-            return "Node.js not available; `node --version` failed."
-        version = r.stdout.strip()
-        match = re.match(r"v(\d+)\.", version)
-        if not match or int(match.group(1)) < MIN_NODE_MAJOR:
-            return f"Node {version} found but JS-SAM requires Node >= {MIN_NODE_MAJOR}."
+        docker_error = _docker_available()
+        if docker_error:
+            return docker_error
+        if not _image_present():
+            return (
+                f"JS-SAM sandbox image '{DOCKER_IMAGE}' not found. "
+                f"Run: docker pull {DOCKER_IMAGE}"
+            )
         if not HELPER_CLI.exists():
             return f"JS-SAM helper not found at {HELPER_CLI}."
         if not HELPER_NODE_MODULES.exists():
             return (
                 f"JS-SAM helper dependencies missing. "
-                f"Run: npm install --prefix {HELPER_DIR}"
+                f"Run: npm ci --prefix {HELPER_DIR}"
             )
-        response, error = _run_helper("ping", {}, timeout=30)
+        # Exercise the full sandboxed path end to end.
+        response, error = _run_helper("ping", {}, timeout=60)
         if error:
             return error
+        version = str(response.get("node", ""))
+        match = re.match(r"v(\d+)\.", version)
+        if not match or int(match.group(1)) < MIN_NODE_MAJOR:
+            return (
+                f"JS-SAM sandbox node {version or '?'} < required v{MIN_NODE_MAJOR} "
+                f"(image {DOCKER_IMAGE})."
+            )
         logger.debug(
-            "JS-SAM helper ready (node %s, sam-pattern %s)",
-            response.get("node"), response.get("samPattern"),
+            "JS-SAM sandbox ready (node %s, sam-pattern %s, image %s)",
+            response.get("node"), response.get("samPattern"), DOCKER_IMAGE,
         )
         return None
 

--- a/tla_eval/tasks/spin/prompts/js-sam/agent_correction.txt
+++ b/tla_eval/tasks/spin/prompts/js-sam/agent_correction.txt
@@ -1,0 +1,54 @@
+You are an expert in the SAM pattern (State-Action-Model, https://sam.js.org) and the @cognitive-fab/sam-pattern JavaScript library, with deep experience in concurrent systems and spinlock synchronization.
+
+I need you to fix errors in a JavaScript SAM specification for a spinlock {system_type} system.
+
+## Original Task Description
+{description}
+
+## Current JS-SAM Specification (with errors)
+```javascript
+{current_specification}
+```
+
+## Validation Errors Found
+**Error Summary:**
+{error_summary}
+
+**Detailed Syntax Errors:**
+{syntax_errors}
+
+**Detailed Semantic Errors:**
+{semantic_errors}
+
+**Full Validation Output:**
+```
+{validation_output}
+```
+
+## Correction Instructions
+This is correction attempt {attempt_number} of {max_attempts}.
+
+Fix the specification so it loads and passes the structural contract check while preserving the intended spinlock semantics.
+
+The module MUST export exactly:
+module.exports = { instance, init, actions, getState, setState, checkerIntents };
+
+Contract checklist (the validator enforces all of these):
+1. `instance` is created with `createInstance({ instanceName: 'spin', hasAsyncActions: false })` — synchronous steps are mandatory
+2. `init()` clears any model error and resets to the initial state
+3. `actions` is an object with the EXACT mandatory action names `AcquireLock` and `ReleaseLock` (hard contract), each a function firing the SAM intent synchronously
+4. `getState()` returns a plain JSON-serializable snapshot (strip '__'-prefixed keys and functions with a JSON.stringify replacer)
+5. `setState(snapshot)` forces the model to a snapshot via `instance({ initialState: deepClone(snapshot) })`
+6. `checkerIntents` is a non-empty array of `{ name, intent, values }` where `values` is a non-empty array of argument arrays (use `[[{}]]` for a no-argument action)
+7. `init()` followed by `getState()` must be deterministic across runs — no I/O, timers, Date, or Math.random
+8. Acceptors guard against invalid proposals (release by a non-holder is a no-op, never a throw)
+9. No component `safety` conditions, no `render`, no console output — invariants are verified separately
+
+Key spinlock semantics to preserve:
+- lock(): blocking — on CAS failure the thread stays 'trying' and may retry
+- try_lock(): non-blocking — on CAS failure the thread returns to 'idle' immediately
+- At most one thread holds the lock; only the holder can release it
+
+CRITICAL OUTPUT REQUIREMENTS:
+1. Output EXACTLY ONE fenced code block: ```javascript ... ```. Nothing outside the fence.
+2. The block must be the complete corrected CommonJS module, not a diff.

--- a/tla_eval/tasks/spin/prompts/js-sam/direct_call.txt
+++ b/tla_eval/tasks/spin/prompts/js-sam/direct_call.txt
@@ -1,0 +1,149 @@
+You are an expert in the SAM pattern (State-Action-Model, https://sam.js.org) — a JavaScript software engineering pattern grounded in TLA+ semantics: actions compute proposals, the model accepts or rejects them in a synchronized step, and state is a pure function of the model.
+
+Convert the following Asterinas OS spinlock source code into an executable JavaScript SAM specification using the @cognitive-fab/sam-pattern library.
+
+System: Asterinas OS spinlock synchronization primitive
+
+Source Code from {file_path}:
+```rust
+{source_code}
+```
+
+Spinlock modeling requirements:
+
+MANDATORY CORE CONCEPTS:
+1. 【Lock/Unlock Operations】Distinguish between lock() and try_lock() with different semantics:
+   - lock(): blocking call that spins until acquisition
+   - try_lock(): non-blocking call that returns immediately
+2. 【Atomic CAS】Model the compare_exchange on the AtomicBool as a single synchronized SAM step
+3. 【Thread States】Model thread states: idle, trying, locked
+4. 【Lock Status】The lock is held by at most one thread
+5. 【Two Threads】Model exactly two threads, with ids 0 and 1
+
+CRITICAL SEMANTIC DISTINCTION:
+- **lock()**: blocking — on CAS failure the thread stays in 'trying' (spinning) and may retry
+- **try_lock()**: non-blocking — on CAS failure the thread returns to 'idle' immediately; it must NEVER remain in 'trying'
+
+## Mandatory module contract (hard requirements)
+
+Your specification is a CommonJS module evaluated by an automated harness. It MUST export exactly this shape:
+
+module.exports = { instance, init, actions, getState, setState, checkerIntents };
+
+- `instance` — the SAM instance, created with:
+  `const instance = createInstance({ instanceName: 'spin', hasAsyncActions: false });`
+  (`hasAsyncActions: false` is REQUIRED — all steps must be synchronous)
+- `init()` — resets the model to its initial state (and clears any error):
+  call `instance({}).state().clearError()` then `setState(INITIAL_STATE)`
+- `actions` — an object with EXACTLY these mandatory action names (hard contract used by trace validation):
+  - `actions.AcquireLock(data)` where data is `{ thread: 0|1, callType: 'lock'|'tryLock' }`
+  - `actions.ReleaseLock(data)` where data is `{ thread: 0|1 }`
+  Each is a function that fires the corresponding SAM intent synchronously.
+- `getState()` — returns a plain JSON-serializable snapshot of the model (no functions, no SAM internals). Use a JSON.stringify replacer that drops keys starting with '__' and function values.
+- `setState(snapshot)` — forces the model to a given snapshot via `instance({ initialState: deepClone(snapshot) })`
+- `checkerIntents` — descriptors for the bundled behavior explorer: an array of `{ name, intent, values }` where `name` is the action name, `intent` is the function from `actions`, and `values` is a non-empty array of argument arrays covering the action's input domain (every thread id and call type combination).
+
+DETERMINISM RULES (violations are detected and fail the evaluation):
+- No I/O, no timers, no Date/clock access, no Math.random, no async actions
+- Acceptors must guard against invalid proposals (e.g. release by a non-holder must be a no-op, NOT a throw)
+- Do NOT include component `safety` conditions or a `render` function — invariants are verified in a separate phase
+
+## In-context example: Rocket Launcher (the SAM community's canonical small system)
+
+```javascript
+'use strict';
+
+const { createInstance } = require('@cognitive-fab/sam-pattern');
+
+const instance = createInstance({ instanceName: 'rocket', hasAsyncActions: false });
+
+// status: 'ready' | 'counting' | 'aborted' | 'launched'
+const INITIAL_STATE = { counter: 10, status: 'ready' };
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const { intents } = instance({
+  initialState: clone(INITIAL_STATE),
+  component: {
+    actions: [
+      () => ({ __name: 'Start', start: true }),
+      () => ({ __name: 'Decrement', decrement: true }),
+      () => ({ __name: 'Abort', abort: true }),
+    ],
+    acceptors: [
+      (model) => ({ start }) => {
+        if (start && model.status === 'ready') model.status = 'counting';
+      },
+      (model) => ({ decrement }) => {
+        if (decrement && model.status === 'counting' && model.counter > 0) model.counter -= 1;
+      },
+      (model) => ({ abort }) => {
+        if (abort && model.status === 'counting') model.status = 'aborted';
+      },
+    ],
+    reactors: [
+      (model) => () => {
+        if (model.status === 'counting' && model.counter === 0) model.status = 'launched';
+      },
+    ],
+  },
+});
+
+const [startIntent, decrementIntent, abortIntent] = intents;
+
+const sanitizeReplacer = (key, value) => {
+  if (typeof key === 'string' && key.startsWith('__')) return undefined;
+  if (typeof value === 'function') return undefined;
+  return value;
+};
+
+const getState = () => JSON.parse(JSON.stringify(instance({}).state(), sanitizeReplacer));
+
+const setState = (snapshot) => { instance({ initialState: clone(snapshot) }); };
+
+const init = () => {
+  instance({}).state().clearError();
+  setState(INITIAL_STATE);
+};
+
+const actions = {
+  Start: (data = {}) => startIntent(data),
+  Decrement: (data = {}) => decrementIntent(data),
+  Abort: (data = {}) => abortIntent(data),
+};
+
+const checkerIntents = [
+  { name: 'Start', intent: actions.Start, values: [[{}]] },
+  { name: 'Decrement', intent: actions.Decrement, values: [[{}]] },
+  { name: 'Abort', intent: actions.Abort, values: [[{}]] },
+];
+
+module.exports = { instance, init, actions, getState, setState, checkerIntents };
+```
+
+## Recommended state shape for the spinlock
+
+To keep trace validation straightforward, prefer this snapshot shape (you may add fields, but these names are strongly recommended):
+
+```javascript
+{
+  lockHeld: false,            // boolean
+  lockHolder: null,           // 0 | 1 | null
+  threadStatus: { 0: 'idle', 1: 'idle' },   // 'idle' | 'trying' | 'locked'
+  callType: { 0: null, 1: null }            // 'lock' | null (pending blocking call)
+}
+```
+
+EXPLICITLY EXCLUDED (do not model):
+- PreemptDisabled vs LocalIrqDisabled guard behaviors
+- Arc-based locking, UnsafeCell implementation details
+- Debug formatting and trait implementations
+- Memory-ordering details beyond the atomicity of the CAS step
+
+CRITICAL OUTPUT REQUIREMENTS:
+1. Output EXACTLY ONE fenced code block: ```javascript ... ```. Nothing outside the fence.
+2. The block must be a complete, self-contained CommonJS module following the contract above.
+3. Set `__name` on every proposal ('AcquireLock' / 'ReleaseLock') so explorer behaviors are readable.
+4. Do not include safety conditions, render functions, assertions, or console output.
+
+Generate the complete JS-SAM specification that accurately models the spinlock's concurrent behavior.

--- a/tla_eval/tasks/spin/prompts/js-sam/phase3_invariant_implementation.txt
+++ b/tla_eval/tasks/spin/prompts/js-sam/phase3_invariant_implementation.txt
@@ -1,0 +1,60 @@
+You are a JavaScript and SAM-pattern expert specializing in concurrent systems and synchronization primitives. Your task is to implement a set of expert-written invariants for the given spinlock JS-SAM specification.
+
+## Target Specification
+
+```javascript
+$javascript_specification
+```
+
+## Invariants to Implement
+
+$invariant_templates
+
+## Implementation Requirements
+
+1. **Deep Analysis**: First, thoroughly understand both the invariant template's semantic intent and the specification's modeling approach:
+   - What safety property does each template aim to verify?
+   - What is the EXACT state shape this specification's getState() produces (field names, value types, thread-id key types)?
+   - What are the semantic equivalents between template concepts and the specification's state fields?
+
+2. **Semantic Mapping**: For each invariant, map template concepts onto the specification's actual state shape:
+   - Template "locked" / "trying" / "idle" statuses → the specification's thread status representation
+   - Template lock ownership → the specification's holder field(s)
+   - **CRITICAL**: Use ONLY fields that actually exist in the specification's state. Do not assume the recommended shape; read the acceptors to confirm what is mutated.
+
+3. **Predicate form**: Each invariant is ONE JavaScript function expression:
+   - Signature: `(state) => boolean`
+   - It receives the plain JSON snapshot produced by getState() — never SAM internals
+   - It MUST return `true` when the invariant HOLDS and `false` when it is VIOLATED
+   - It must be pure: no mutation, no I/O, no exceptions on any reachable state
+   - Defensive access: prefer `Object.values(state.threadStatus || {})` style guards so the predicate never throws
+
+4. **Bounded checking note**: The SAM behavior explorer performs bounded exploration of all intent permutations. Liveness properties cannot be verified; if a template is a liveness property, convert it to a bounded safety property where possible, or omit it.
+
+5. **Output format**: Return a JSON object with an `invariants` array of objects, each carrying the EXACT template name and the predicate source as a string.
+
+## Example Output Format
+
+```json
+{
+  "invariants": [
+    {
+      "name": "MutualExclusion",
+      "predicate": "(state) => Object.values(state.threadStatus || {}).filter((s) => s === 'locked').length <= 1"
+    },
+    {
+      "name": "LockStatusConsistency",
+      "predicate": "(state) => state.lockHolder === null || state.lockHolder === undefined || (state.threadStatus || {})[String(state.lockHolder)] === 'locked'"
+    }
+  ]
+}
+```
+
+**CRITICAL REQUIREMENTS**:
+- Use EXACTLY the invariant names from the templates above — do not invent names
+- `predicate` is a single arrow-function expression in a JSON string — use proper JSON escaping
+- `true` = invariant holds; `false` = violation (the explorer reports a counterexample behavior on `false`)
+- Use ONLY state fields that exist in the provided specification
+- Do NOT use JavaScript template literals (backticks) inside predicates
+- Return ONLY valid JSON, no explanatory text before or after
+- Start your response immediately with the opening brace

--- a/tools/js-sam/cli.mjs
+++ b/tools/js-sam/cli.mjs
@@ -1,0 +1,593 @@
+/**
+ * JS-SAM evaluation helper.
+ *
+ * The Python backend (tla_eval/languages/js_sam.py) shells out to this CLI
+ * with one subcommand per evaluation phase. Every subcommand reads a single
+ * JSON request on stdin and writes a single JSON response on stdout.
+ *
+ * Exit code 0 means "the helper ran"; pass/fail is carried inside the JSON
+ * (mirroring the PAT backend, whose console always exits 0). A non-zero exit
+ * or malformed JSON is a tooling failure, not a spec failure.
+ *
+ * Subcommands:
+ *   ping         — tool diagnostics ({} -> { ok, node, samPattern })
+ *   validate     — Phase 1: parse + load + structural contract check
+ *   check        — Phase 2: bounded behavior exploration (sam-pattern checker)
+ *   transitions  — Phase 3: replay (pre, action, post) trace windows
+ *   invariants   — Phase 4: explore with translated safety predicates
+ *
+ * Generated specs are CommonJS modules that must export:
+ *   { instance, init, actions, getState, setState, checkerIntents }
+ * See tla_eval/tasks/<task>/prompts/js-sam/direct_call.txt for the contract.
+ */
+
+import { createRequire } from 'node:module';
+import Module from 'node:module';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const HELPER_DIR = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+// Generated specs live in arbitrary work dirs, so their
+// require('@cognitive-fab/sam-pattern') would not resolve by walking up from
+// the spec file. Append the helper's node_modules to the global resolution
+// paths before any spec is loaded.
+process.env.NODE_PATH = [path.join(HELPER_DIR, 'node_modules'), process.env.NODE_PATH]
+  .filter(Boolean)
+  .join(path.delimiter);
+Module._initPaths();
+
+const { checker } = require('@cognitive-fab/sam-pattern');
+
+const DEFAULT_DEPTH_MAX = 6;
+const MAX_REPORTED_VIOLATIONS = 5;
+const MAX_REPORTED_WINDOW_FAILURES = 20;
+
+// SAM rejects gated intents by presenting { __error: 'unexpected action …' }.
+// That is legal model behavior (a rejected action), not a runtime fault.
+const REJECTION_PREFIX = 'unexpected action';
+
+// sam-pattern invokes acceptors through an async wrapper, so an acceptor
+// throw surfaces as an unhandled promise rejection (which would kill this
+// process) instead of a synchronous exception. Collect them and let each
+// subcommand drain the queue at a point where it can attribute the failure.
+const pendingAsyncErrors = [];
+process.on('unhandledRejection', (reason) => {
+  if (pendingAsyncErrors.length < 50) {
+    pendingAsyncErrors.push(reason instanceof Error ? reason.message : String(reason));
+  }
+});
+
+/** Lets queued microtasks/timers settle, then returns the captured errors. */
+const drainAsyncErrors = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return pendingAsyncErrors.splice(0);
+};
+
+/** Strips SAM-internal (__-prefixed) keys and functions from a state tree. */
+const sanitizeReplacer = (key, value) => {
+  if (typeof key === 'string' && key.startsWith('__')) return undefined;
+  if (typeof value === 'function') return undefined;
+  return value;
+};
+
+/** @returns {object} a plain JSON snapshot of a live SAM model/state. */
+const plainSnapshot = (state) => JSON.parse(JSON.stringify(state, sanitizeReplacer));
+
+const isRejectionError = (rawError) => {
+  const text = typeof rawError === 'string' ? rawError : (rawError && rawError.message) || '';
+  return text.startsWith(REJECTION_PREFIX);
+};
+
+/** Reads the model's error slot through the module's exported instance. */
+const readModelError = (mod) => {
+  const model = mod.instance({}).state();
+  if (!model.hasError()) return null;
+  const raw = model.error();
+  const message = model.errorMessage() ?? String(raw ?? 'unknown error');
+  return { raw, message, isRejection: isRejectionError(raw) };
+};
+
+const clearModelError = (mod) => {
+  mod.instance({}).state().clearError();
+};
+
+// ---------------------------------------------------------------------------
+// Spec loading + structural contract check
+// ---------------------------------------------------------------------------
+
+/**
+ * Loads a generated spec and verifies the module contract.
+ *
+ * @param {string} specPath absolute path to the generated .js module
+ * @param {string[]} targetActions mandatory action names ([] to skip)
+ * @returns {{ mod?: object, syntaxErrors: string[], semanticErrors: string[] }}
+ */
+const loadSpec = (specPath, targetActions = []) => {
+  const syntaxErrors = [];
+  const semanticErrors = [];
+  let mod;
+
+  try {
+    mod = require(path.resolve(specPath));
+  } catch (err) {
+    const description = `${err.name ?? 'Error'}: ${err.message}`;
+    if (err instanceof SyntaxError) {
+      syntaxErrors.push(description);
+    } else {
+      semanticErrors.push(`Module failed to load: ${description}`);
+    }
+    return { syntaxErrors, semanticErrors };
+  }
+
+  if (mod == null || typeof mod !== 'object') {
+    semanticErrors.push('module.exports is not an object');
+    return { syntaxErrors, semanticErrors };
+  }
+
+  for (const fn of ['init', 'getState', 'setState', 'instance']) {
+    if (typeof mod[fn] !== 'function') {
+      semanticErrors.push(`Missing or non-function export: ${fn}`);
+    }
+  }
+
+  if (mod.actions == null || typeof mod.actions !== 'object') {
+    semanticErrors.push('Missing export: actions (object mapping action name -> function)');
+  } else {
+    for (const [name, fn] of Object.entries(mod.actions)) {
+      if (typeof fn !== 'function') {
+        semanticErrors.push(`actions.${name} is not a function`);
+      }
+    }
+    for (const name of targetActions) {
+      if (typeof mod.actions[name] !== 'function') {
+        semanticErrors.push(`Mandatory target action missing from actions: ${name}`);
+      }
+    }
+  }
+
+  if (!Array.isArray(mod.checkerIntents) || mod.checkerIntents.length === 0) {
+    semanticErrors.push('Missing export: checkerIntents (non-empty array of { name, intent, values })');
+  } else {
+    mod.checkerIntents.forEach((descriptor, index) => {
+      if (descriptor == null || typeof descriptor !== 'object') {
+        semanticErrors.push(`checkerIntents[${index}] is not an object`);
+        return;
+      }
+      if (typeof descriptor.name !== 'string') {
+        semanticErrors.push(`checkerIntents[${index}].name is not a string`);
+      }
+      if (typeof descriptor.intent !== 'function') {
+        semanticErrors.push(`checkerIntents[${index}].intent is not a function`);
+      }
+      if (!Array.isArray(descriptor.values) || descriptor.values.length === 0
+          || !descriptor.values.every(Array.isArray)) {
+        semanticErrors.push(
+          `checkerIntents[${index}].values must be a non-empty array of argument arrays `
+          + '(use [[]] for an action with no arguments)',
+        );
+      }
+    });
+  }
+
+  if (semanticErrors.length > 0) {
+    return { syntaxErrors, semanticErrors };
+  }
+
+  // Smoke checks: init/getState must work and be deterministic + serializable.
+  try {
+    mod.init();
+    const first = JSON.stringify(mod.getState());
+    mod.init();
+    const second = JSON.stringify(mod.getState());
+    if (typeof mod.getState() !== 'object' || mod.getState() == null) {
+      semanticErrors.push('getState() did not return an object');
+    } else if (first !== second) {
+      semanticErrors.push('init() + getState() is not deterministic across two runs');
+    }
+  } catch (err) {
+    semanticErrors.push(`init()/getState() smoke check threw: ${err.message}`);
+  }
+
+  return { mod, syntaxErrors, semanticErrors };
+};
+
+// ---------------------------------------------------------------------------
+// Bounded exploration (shared by `check` and `invariants`)
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs the sam-pattern behavior explorer over all intent permutations.
+ *
+ * @param {object} mod loaded spec module
+ * @param {number} depthMax exploration depth bound
+ * @param {Array<{name: string, holds: (state: object) => boolean}>} predicates
+ *        safety predicates that must hold in every reachable state
+ * @returns {{ steps: number, runtimeErrors: object[], violations: object[],
+ *             predicateErrors: object[], serializationErrors: string[] }}
+ */
+const explore = (mod, depthMax, predicates = []) => {
+  const runtimeErrors = [];
+  const violations = [];
+  const predicateErrors = [];
+  const serializationErrors = [];
+  let steps = 0;
+
+  const safety = (state) => {
+    steps += 1;
+
+    // Unhandled exceptions surface in the model's error slot. Rejected
+    // (gated) actions use the same slot but are legal behavior.
+    if (state.hasError()) {
+      const raw = state.error();
+      const message = state.errorMessage() ?? String(raw ?? 'unknown error');
+      const rejection = isRejectionError(raw);
+      state.clearError();
+      if (!rejection && runtimeErrors.length < MAX_REPORTED_VIOLATIONS) {
+        runtimeErrors.push({ message, behavior: [...(state.__behavior ?? [])] });
+      }
+      if (!rejection) return false; // recorded separately, not as a predicate violation
+    }
+
+    let snapshot;
+    try {
+      snapshot = plainSnapshot(state);
+    } catch (err) {
+      if (serializationErrors.length < MAX_REPORTED_VIOLATIONS) {
+        serializationErrors.push(`State is not JSON-serializable: ${err.message}`);
+      }
+      return false;
+    }
+
+    for (const predicate of predicates) {
+      let holds;
+      try {
+        holds = predicate.holds(snapshot);
+      } catch (err) {
+        if (predicateErrors.length < MAX_REPORTED_VIOLATIONS) {
+          predicateErrors.push({ name: predicate.name, message: err.message });
+        }
+        continue;
+      }
+      if (!holds) return true; // checker records the violating behavior
+    }
+    return false;
+  };
+
+  clearModelError(mod);
+  mod.init();
+  checker(
+    {
+      instance: mod.instance,
+      intents: mod.checkerIntents,
+      reset: () => mod.init(),
+      safety,
+      options: { depthMax },
+    },
+    () => {},
+    (behavior) => {
+      if (violations.length < MAX_REPORTED_VIOLATIONS) {
+        violations.push({ behavior: Array.isArray(behavior) ? [...behavior] : behavior });
+      }
+    },
+  );
+
+  return { steps, runtimeErrors, violations, predicateErrors, serializationErrors };
+};
+
+// ---------------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------------
+
+const cmdPing = () => ({
+  ok: true,
+  node: process.version,
+  samPattern: require('@cognitive-fab/sam-pattern/package.json').version,
+  samFsm: require('@cognitive-fab/sam-fsm/package.json').version,
+});
+
+const cmdValidate = (request) => {
+  const { specPath, targetActions = [] } = request;
+  const { syntaxErrors, semanticErrors } = loadSpec(specPath, targetActions);
+  return {
+    ok: true,
+    success: syntaxErrors.length === 0 && semanticErrors.length === 0,
+    syntaxErrors,
+    semanticErrors,
+  };
+};
+
+const cmdCheck = async (request) => {
+  const { specPath, depthMax = DEFAULT_DEPTH_MAX, targetActions = [] } = request;
+  const { mod, syntaxErrors, semanticErrors } = loadSpec(specPath, targetActions);
+  if (!mod) {
+    return {
+      ok: true,
+      success: false,
+      classification: 'parse_error',
+      errors: [...syntaxErrors, ...semanticErrors],
+    };
+  }
+
+  const started = Date.now();
+  let first;
+  let second;
+  try {
+    const dedupe = (messages) => [...new Set(messages)].slice(0, MAX_REPORTED_VIOLATIONS);
+    first = explore(mod, depthMax);
+    first.runtimeErrors.push(...dedupe(await drainAsyncErrors()).map((message) => ({ message, behavior: [] })));
+    // Second pass over the identical exploration: any digest difference means
+    // the spec depends on nondeterminism (randomness, time, ambient state).
+    second = explore(mod, depthMax);
+    second.runtimeErrors.push(...dedupe(await drainAsyncErrors()).map((message) => ({ message, behavior: [] })));
+  } catch (err) {
+    return {
+      ok: true,
+      success: false,
+      classification: 'runtime_error',
+      errors: [`Behavior exploration aborted: ${err.message}`],
+      elapsedMs: Date.now() - started,
+    };
+  }
+  const elapsedMs = Date.now() - started;
+
+  const digest = (run) => JSON.stringify([run.steps, run.runtimeErrors, run.serializationErrors]);
+  const isDeterministic = digest(first) === digest(second);
+
+  let classification = null;
+  const errors = [];
+  if (first.runtimeErrors.length > 0) {
+    classification = 'runtime_error';
+    errors.push(...new Set(first.runtimeErrors.map((e) => e.message)));
+  } else if (first.serializationErrors.length > 0) {
+    classification = 'runtime_error';
+    errors.push(...first.serializationErrors);
+  } else if (!isDeterministic) {
+    classification = 'nondeterminism';
+    errors.push('Two identical explorations produced different outcomes.');
+  }
+
+  return {
+    ok: true,
+    success: classification === null,
+    classification,
+    depthMax,
+    stepsExplored: first.steps,
+    runtimeErrors: first.runtimeErrors,
+    errors,
+    elapsedMs,
+  };
+};
+
+/**
+ * Deep projection diff: every key present in `expected` must be (deeply)
+ * equal in `actual`. Keys present only in `actual` are model-internal
+ * bookkeeping and are ignored. `null` and `undefined` are equivalent.
+ *
+ * @returns {string[]} mismatch descriptions (empty when the window matches)
+ */
+const projectionDiff = (expected, actual, prefix = '') => {
+  if (expected === null || expected === undefined) {
+    return actual === null || actual === undefined
+      ? []
+      : [`${prefix || '$'}: expected null, got ${JSON.stringify(actual)}`];
+  }
+  if (typeof expected !== 'object') {
+    return Object.is(expected, actual)
+      ? []
+      : [`${prefix || '$'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`];
+  }
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length !== expected.length) {
+      return [`${prefix || '$'}: expected array ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`];
+    }
+    return expected.flatMap((item, i) => projectionDiff(item, actual[i], `${prefix}[${i}]`));
+  }
+  if (actual === null || actual === undefined || typeof actual !== 'object') {
+    return [`${prefix || '$'}: expected object, got ${JSON.stringify(actual)}`];
+  }
+  return Object.keys(expected).flatMap((key) => (
+    projectionDiff(expected[key], actual[key], prefix ? `${prefix}.${key}` : key)
+  ));
+};
+
+const cmdTransitions = async (request) => {
+  const { specPath, windows = [], targetActions = [] } = request;
+  const { mod, syntaxErrors, semanticErrors } = loadSpec(specPath, targetActions);
+  if (!mod) {
+    return {
+      ok: true,
+      success: false,
+      error: `Spec failed to load: ${[...syntaxErrors, ...semanticErrors].join('; ')}`,
+    };
+  }
+
+  const perAction = {};
+  const failures = [];
+  let totalPassed = 0;
+
+  const record = (action, passed, windowIndex, reason) => {
+    const bucket = perAction[action] ?? (perAction[action] = { passed: 0, total: 0 });
+    bucket.total += 1;
+    if (passed) {
+      bucket.passed += 1;
+      totalPassed += 1;
+    } else if (failures.length < MAX_REPORTED_WINDOW_FAILURES) {
+      failures.push({ window: windowIndex, action, reason });
+    }
+  };
+
+  for (const [index, window] of windows.entries()) {
+    const { action, data = {}, preState, postState } = window;
+    try {
+      const handler = mod.actions[action];
+      if (typeof handler !== 'function') {
+        record(action, false, index, `action '${action}' is not exported by the spec`);
+        continue;
+      }
+      mod.init();
+      clearModelError(mod);
+      mod.setState(preState);
+      handler(data);
+
+      // Acceptor exceptions surface asynchronously; settle them before diffing
+      // so the failure is attributed to this window.
+      const asyncErrors = await drainAsyncErrors();
+      if (asyncErrors.length > 0) {
+        record(action, false, index, `action threw: ${asyncErrors[0]}`);
+        continue;
+      }
+
+      const modelError = readModelError(mod);
+      if (modelError) {
+        clearModelError(mod);
+        const kind = modelError.isRejection ? 'rejected by the model' : 'threw';
+        record(action, false, index, `action ${kind}: ${modelError.message}`);
+        continue;
+      }
+
+      const mismatches = projectionDiff(postState, mod.getState());
+      record(action, mismatches.length === 0, index, mismatches.slice(0, 5).join('; '));
+    } catch (err) {
+      record(action, false, index, `replay raised: ${err.message}`);
+    }
+  }
+
+  for (const bucket of Object.values(perAction)) {
+    bucket.rate = bucket.total > 0 ? bucket.passed / bucket.total : 0;
+  }
+
+  return {
+    ok: true,
+    success: true,
+    totalPassed,
+    totalWindows: windows.length,
+    perAction,
+    failures,
+  };
+};
+
+const cmdInvariants = async (request) => {
+  const { specPath, invariants = [], depthMax = DEFAULT_DEPTH_MAX, targetActions = [] } = request;
+  const { mod, syntaxErrors, semanticErrors } = loadSpec(specPath, targetActions);
+  if (!mod) {
+    return {
+      ok: true,
+      success: false,
+      error: `Spec failed to load: ${[...syntaxErrors, ...semanticErrors].join('; ')}`,
+    };
+  }
+
+  const results = [];
+  for (const { name, predicate } of invariants) {
+    const started = Date.now();
+    let holds;
+    try {
+      // The translated predicate is a JS arrow/function expression:
+      // (state) => boolean, true when the invariant HOLDS.
+      holds = (0, eval)(`(${predicate})`);
+      if (typeof holds !== 'function') {
+        throw new TypeError('predicate did not evaluate to a function');
+      }
+    } catch (err) {
+      results.push({
+        name,
+        success: false,
+        error: `Predicate failed to compile: ${err.message}`,
+        elapsedMs: Date.now() - started,
+      });
+      continue;
+    }
+
+    let run;
+    try {
+      run = explore(mod, depthMax, [{ name, holds }]);
+      run.runtimeErrors.push(...(await drainAsyncErrors()).map((message) => ({ message, behavior: [] })));
+    } catch (err) {
+      results.push({
+        name,
+        success: false,
+        error: `Exploration aborted: ${err.message}`,
+        elapsedMs: Date.now() - started,
+      });
+      continue;
+    }
+
+    const problems = [];
+    if (run.violations.length > 0) {
+      problems.push(`invariant violated in ${run.violations.length}+ behavior(s)`);
+    }
+    if (run.predicateErrors.length > 0) {
+      problems.push(`predicate threw: ${run.predicateErrors[0].message}`);
+    }
+    if (run.runtimeErrors.length > 0) {
+      problems.push(`spec raised during exploration: ${run.runtimeErrors[0].message}`);
+    }
+
+    results.push({
+      name,
+      success: problems.length === 0,
+      error: problems.length > 0 ? problems.join('; ') : null,
+      counterexample: run.violations[0]?.behavior ?? null,
+      stepsExplored: run.steps,
+      elapsedMs: Date.now() - started,
+    });
+  }
+
+  return { ok: true, success: true, results };
+};
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+const COMMANDS = {
+  ping: cmdPing,
+  validate: cmdValidate,
+  check: cmdCheck,
+  transitions: cmdTransitions,
+  invariants: cmdInvariants,
+};
+
+const readStdin = async () => {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf-8');
+};
+
+const main = async () => {
+  const subcommand = process.argv[2];
+  const handler = COMMANDS[subcommand];
+  if (!handler) {
+    process.stdout.write(JSON.stringify({
+      ok: false,
+      error: `Unknown subcommand '${subcommand}'. Expected one of: ${Object.keys(COMMANDS).join(', ')}`,
+    }));
+    process.exitCode = 2;
+    return;
+  }
+
+  let request = {};
+  if (subcommand !== 'ping') {
+    const raw = await readStdin();
+    try {
+      request = raw.trim() ? JSON.parse(raw) : {};
+    } catch (err) {
+      process.stdout.write(JSON.stringify({ ok: false, error: `Invalid JSON request: ${err.message}` }));
+      process.exitCode = 2;
+      return;
+    }
+  }
+
+  try {
+    const response = await handler(request);
+    process.stdout.write(JSON.stringify(response));
+  } catch (err) {
+    process.stdout.write(JSON.stringify({ ok: false, error: `${err.name}: ${err.message}`, stack: err.stack }));
+    process.exitCode = 1;
+  }
+};
+
+await main();

--- a/tools/js-sam/package-lock.json
+++ b/tools/js-sam/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "sysmobench-js-sam-helper",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sysmobench-js-sam-helper",
+      "version": "0.1.0",
+      "dependencies": {
+        "@cognitive-fab/sam-fsm": "^1.0.0",
+        "@cognitive-fab/sam-pattern": "^1.6.1",
+        "sam-fsm": "npm:@cognitive-fab/sam-fsm@^1.0.0",
+        "sam-pattern": "npm:@cognitive-fab/sam-pattern@^1.6.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cognitive-fab/sam-fsm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cognitive-fab/sam-fsm/-/sam-fsm-1.0.0.tgz",
+      "integrity": "sha512-Eh8xjWYTWLz9TvJtyJ+SkM4WDQy80OaZEqRnXeb7Kic+fIXz46EcDVlMBj5lhpjfFV7yE7XPLHFPSkVD3527zA==",
+      "license": "ISC"
+    },
+    "node_modules/@cognitive-fab/sam-pattern": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@cognitive-fab/sam-pattern/-/sam-pattern-1.6.1.tgz",
+      "integrity": "sha512-ukdWYJNWaXgzhZrFAXLwgNasopxx03pN4lXoE49fvNPAYLxBQBw1qxQQF/DaBR0GjuiTtptnhoR3yfjEywbalA==",
+      "license": "ISC"
+    },
+    "node_modules/sam-fsm": {
+      "name": "@cognitive-fab/sam-fsm",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cognitive-fab/sam-fsm/-/sam-fsm-1.0.0.tgz",
+      "integrity": "sha512-Eh8xjWYTWLz9TvJtyJ+SkM4WDQy80OaZEqRnXeb7Kic+fIXz46EcDVlMBj5lhpjfFV7yE7XPLHFPSkVD3527zA==",
+      "license": "ISC"
+    },
+    "node_modules/sam-pattern": {
+      "name": "@cognitive-fab/sam-pattern",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@cognitive-fab/sam-pattern/-/sam-pattern-1.6.1.tgz",
+      "integrity": "sha512-ukdWYJNWaXgzhZrFAXLwgNasopxx03pN4lXoE49fvNPAYLxBQBw1qxQQF/DaBR0GjuiTtptnhoR3yfjEywbalA==",
+      "license": "ISC"
+    }
+  }
+}

--- a/tools/js-sam/package.json
+++ b/tools/js-sam/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sysmobench-js-sam-helper",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Node helper the JS-SAM LanguageBackend shells out to (JSON-in / JSON-out).",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@cognitive-fab/sam-pattern": "^1.6.1",
+    "@cognitive-fab/sam-fsm": "^1.0.0",
+    "sam-pattern": "npm:@cognitive-fab/sam-pattern@^1.6.1",
+    "sam-fsm": "npm:@cognitive-fab/sam-fsm@^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a fourth specification language: **JavaScript using the SAM pattern** ([sam.js.org](https://sam.js.org)), via [`@cognitive-fab/sam-pattern`](https://www.npmjs.com/package/@cognitive-fab/sam-pattern) and [`@cognitive-fab/sam-fsm`](https://www.npmjs.com/package/@cognitive-fab/sam-fsm).

SAM is grounded in TLA+ semantics — actions present proposals, a model accepts them, state is a pure function of the model — but the artifact is an **executable .js module**. This is the bench's first non-formal-language backend, testing a different hypothesis: can LLMs produce correct system specs in a pattern they see constantly in training data, rather than in a formal language they rarely see?

Full design rationale, user stories, and decision log: `docs/js_sam_backend_spec.md`.
New to the project? Start with `docs/js_sam_walkthrough.md` — a from-scratch explainer of the integration, every test that was run, and what it demonstrates.

## How it fits

One `LanguageBackend` subclass (`tla_eval/languages/js_sam.py`) plus a small Node helper (`tools/js-sam/cli.mjs`, JSON-in/JSON-out) the Python side shells out to — the same shape as the Alloy and PAT backends. No new CLI plumbing.

- **Phase 1** — parse + load + structural check of the mandatory module contract (`instance`, `init`, `actions`, `getState`, `setState`, `checkerIntents`)
- **Phase 2** — the sam-pattern bundled behavior explorer (bench-wide `depthMax: 6`), with runtime-error / nondeterminism / timeout classification aligned to the existing vocabulary
- **Phase 3** — first backend to use the **direct path** from `docs/add_new_spec_language.md` §3.3: SAM trace replay is `setState(pre); actions[name](data); diff(getState(), post)`. Runs in seconds, no agent, no API spend. Per §3.3 this lands the evaluator-side work with it: a language-neutral NDJSON trace loader (`trace_loader.py`) and the previously-stubbed direct branch in `transition_validation.py`
- **Phase 4** — translated invariants are `(state) => boolean` predicates checked by the explorer; agent translators remap to a direct API call, matching the Alloy (`alloy.py`) and PAT (`pat.py`) precedent

Scope matches Alloy/PAT's historical footprint: **spin only**, `direct_call`, 3 starter invariants (safety-only, same bounded-checking rationale as Alloy's library), Rocket Launcher as the in-context example.

## Incidental fixes

- `scripts/run_benchmark.py`: the unconditional TLA+ (java + tla2tools.jar) prerequisite gate now applies only when the TLA+ backend is selected; other languages rely on their own `check_available()`. A Node-only machine can now run JS-SAM end to end.
- Resolved the contract ambiguity between the stale comment in `transition_validation.py` ("trace loading is the backend's responsibility") and the `base.py` `validate_transitions` signature (windows passed in) — in favor of the signature; docs updated.

## Testing

- 29 new tests (all passing): backend integration through the real Node helper, trace loader (both NDJSON record shapes), and the direct-path evaluator. Known-good / known-bad spec fixtures plus synthetic traces under `tests/fixtures/js_sam/`.
- §6 end-to-end checkpoint passes: `run_benchmark.py --metric compilation_check --language JS-SAM --spec-file tests/fixtures/js_sam/specs/spin-good.js`
- Reference spin model explores ~327k states in ~2.7s at depth 6; a deliberately buggy release model fails exactly the windows exercising the bug.

## Open questions for maintainers (details in the spec doc §9)

1. Is a runtime-pattern language in scope for the leaderboard? ("working SAM model" vs "sound TLA+ spec")
2. Captured `spin` NDJSON traces (`data/sys_traces/spin`) are not in the repo — will they be published, or is harness execution expected per-evaluator? Unit tests use synthetic fixtures; the leaderboard Phase 3 number is blocked on real traces.
3. Depth-bound governance: `depthMax: 6` is a bench-wide constant for the first cut — per-task later?
4. If real agent paths for invariant translation ever land for Alloy/PAT, JS-SAM should share that infrastructure rather than keep the remap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


