### PR TITLE
invariant_verification: strip model assertions/constraints from base cfg before the expert check

### DIFF
--- a/tests/test_languages/test_tla_plus.py
+++ b/tests/test_languages/test_tla_plus.py
@@ -1,0 +1,545 @@
+"""
+Tests for the TLA+ backend's cfg-handling helpers.
+
+The strip helper protects the phase-4 invariant check from being contaminated
+by model-supplied INVARIANT / PROPERTY / CONSTRAINT / ACTION_CONSTRAINT /
+POSTCONDITION sections in the base cfg forwarded from phase 2.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from tla_eval.languages.tla_plus import _strip_user_supplied_assertions
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_TLC_JAR = _PROJECT_ROOT / "lib" / "tla2tools.jar"
+# Behavioral tests need both the jar and a JVM on PATH; gate on both so a
+# missing `java` skips rather than errors.
+_TLC_AVAILABLE = _TLC_JAR.exists() and shutil.which("java") is not None
+_TLC_SKIP_REASON = (
+    "TLC unavailable: need lib/tla2tools.jar (run `sysmobench-setup`) and `java` on PATH."
+)
+
+
+def test_strip_one_liner_invariant_and_property():
+    """One-liner INVARIANT / PROPERTY entries are removed from the base cfg."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        CONSTANT Max = 3
+
+        INVARIANT ModelTypeOK
+        INVARIANT ModelNoOverflow
+        PROPERTY ModelTermination
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "ModelTypeOK" not in out
+    assert "ModelNoOverflow" not in out
+    assert "ModelTermination" not in out
+    # Keepers survive.
+    assert "SPECIFICATION Spec" in out
+    assert "CONSTANT Max = 3" in out
+
+
+def test_strip_block_form_invariants_and_properties():
+    """Block-form INVARIANTS / PROPERTIES with indented continuation lines."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        CONSTANT Nodes = {1, 2, 3}
+
+        INVARIANTS
+            ModelOneLeader
+            ModelLogConsistency
+
+        PROPERTIES
+            ModelEventualConsistency
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "ModelOneLeader" not in out
+    assert "ModelLogConsistency" not in out
+    assert "ModelEventualConsistency" not in out
+    assert "SPECIFICATION Spec" in out
+    assert "Nodes = {1, 2, 3}" in out
+
+
+def test_strip_constraint_and_action_constraint():
+    """CONSTRAINT / ACTION_CONSTRAINT shrink the state space and must be stripped."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        CONSTANT Bound = 5
+
+        CONSTRAINT ModelStateBound
+        ACTION_CONSTRAINT ModelStepBound
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "ModelStateBound" not in out
+    assert "ModelStepBound" not in out
+    assert "CONSTRAINT" not in out
+    assert "ACTION_CONSTRAINT" not in out
+    assert "SPECIFICATION Spec" in out
+    assert "CONSTANT Bound = 5" in out
+
+
+def test_strip_plural_constraint_keywords():
+    """CONSTRAINTS / ACTION_CONSTRAINTS (plural) are valid TLC keywords too —
+    a model emitting the plural form must not slip past the strip."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        CONSTRAINTS
+            ModelStateBoundA
+            ModelStateBoundB
+        ACTION_CONSTRAINTS
+            ModelStepBoundA
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "ModelStateBoundA" not in out
+    assert "ModelStateBoundB" not in out
+    assert "ModelStepBoundA" not in out
+    assert "CONSTRAINTS" not in out
+    assert "ACTION_CONSTRAINTS" not in out
+    assert "SPECIFICATION Spec" in out
+
+
+def test_strip_postcondition():
+    """POSTCONDITION is in the same risk class as INVARIANT and is stripped."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        POSTCONDITION ModelEndCheck
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "ModelEndCheck" not in out
+    assert "POSTCONDITION" not in out
+
+
+def test_strip_plural_postcondition():
+    """POSTCONDITIONS (plural) is a valid TLC keyword and must be stripped in
+    both one-liner and block form, like the other plural variants."""
+    one_liner = _strip_user_supplied_assertions(
+        "SPECIFICATION Spec\nPOSTCONDITIONS ModelPost\n"
+    )
+    assert "ModelPost" not in one_liner
+    assert "POSTCONDITIONS" not in one_liner
+
+    block = _strip_user_supplied_assertions(
+        "SPECIFICATION Spec\nPOSTCONDITIONS\n    ModelPostA\n    ModelPostB\n"
+    )
+    assert "ModelPostA" not in block
+    assert "ModelPostB" not in block
+    assert "POSTCONDITIONS" not in block
+    assert "SPECIFICATION Spec" in block
+
+
+def test_strip_inline_block_comment_before_keyword():
+    """A `(* ... *)` block comment before a section keyword on the same line
+    must not hide the keyword: TLC honors `(* c *) INVARIANT Foo`, so the strip
+    has to as well or model assertions leak past it."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        (* model note *) INVARIANT ModelHaltsAt5
+        (* x *) CONSTRAINT ModelBound
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "ModelHaltsAt5" not in out
+    assert "ModelBound" not in out
+    assert "INVARIANT" not in out
+    assert "CONSTRAINT" not in out
+    assert "SPECIFICATION Spec" in out
+
+
+def test_block_comment_keyword_is_not_a_section_header():
+    """A section keyword that appears only inside a `(* ... *)` block comment is
+    commentary, not a header, and must not flip the parser into drop mode and
+    swallow following kept content."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        (* note: the INVARIANT below is intentional
+           and PROPERTY handling is documented here *)
+        CONSTANT Max = 3
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "SPECIFICATION Spec" in out
+    assert "CONSTANT Max = 3" in out
+
+
+def test_comment_inside_dropped_section_does_not_leak():
+    """A comment that annotates a stripped section is dropped with it, instead
+    of dangling, detached, in the output."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        INVARIANT
+            \\* the model invariant list
+            ModelInv
+        CONSTANT Max = 3
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "ModelInv" not in out
+    assert "the model invariant list" not in out
+    assert "SPECIFICATION Spec" in out
+    assert "CONSTANT Max = 3" in out
+
+
+def test_keyword_named_constant_binding_is_preserved():
+    """A constant whose name collides with an assertion keyword (e.g. a binding
+    `PROPERTY = TRUE` under CONSTANT) is an assignment, not a section header,
+    and the binding (plus following bindings) must survive."""
+    cfg = dedent("""\
+        CONSTANT
+            N = 3
+            PROPERTY = TRUE
+            M = 5
+        INVARIANT <- SomeOp
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "N = 3" in out
+    assert "PROPERTY = TRUE" in out
+    assert "M = 5" in out
+    assert "INVARIANT <- SomeOp" in out
+
+
+def test_crlf_input_is_normalized():
+    """CRLF line endings are normalized so kept lines do not carry a stray
+    carriage return into the composed cfg."""
+    out = _strip_user_supplied_assertions(
+        "SPECIFICATION Spec\r\nCONSTANT Max = 3\r\nINVARIANT ModelInv\r\n"
+    )
+    assert "\r" not in out
+    assert "ModelInv" not in out
+    assert "SPECIFICATION Spec" in out
+
+
+def test_preserves_non_assertion_sections():
+    """Non-assertion sections survive: SPECIFICATION, INIT, NEXT, CONSTANT(S),
+    SYMMETRY, VIEW, ALIAS, CHECK_DEADLOCK, plus comments and blank lines."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        INIT InitState
+        NEXT NextRel
+        CONSTANT
+            N = 3
+            Values = {0, 1}
+        SYMMETRY SymNodes
+        VIEW StateView
+        ALIAS AliasName
+        CHECK_DEADLOCK FALSE
+
+        \\* This comment must survive
+        INVARIANT ModelToBeDropped
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    # Kept.
+    assert "SPECIFICATION Spec" in out
+    assert "INIT InitState" in out
+    assert "NEXT NextRel" in out
+    assert "N = 3" in out
+    assert "Values = {0, 1}" in out
+    assert "SYMMETRY SymNodes" in out
+    assert "VIEW StateView" in out
+    assert "ALIAS AliasName" in out
+    assert "CHECK_DEADLOCK FALSE" in out
+    assert "This comment must survive" in out
+    # Dropped.
+    assert "ModelToBeDropped" not in out
+
+
+def test_section_boundary_recovers_into_keep():
+    """A KEEP section header immediately following a DROP section must end the drop."""
+    cfg = dedent("""\
+        INVARIANT ModelOne
+
+        SPECIFICATION Spec
+        CONSTANT Max = 3
+        """)
+    out = _strip_user_supplied_assertions(cfg)
+
+    assert "ModelOne" not in out
+    assert "SPECIFICATION Spec" in out
+    assert "CONSTANT Max = 3" in out
+
+
+def test_idempotent():
+    """Re-stripping a stripped cfg is a no-op."""
+    cfg = dedent("""\
+        SPECIFICATION Spec
+        CONSTANT Max = 3
+        """)
+    once = _strip_user_supplied_assertions(cfg)
+    twice = _strip_user_supplied_assertions(once)
+
+    assert once == twice
+
+
+def test_final_cfg_sent_to_tlc_contains_only_expert_invariant():
+    """End-to-end: a contaminated base cfg, run through the strip and the
+    per-invariant composition path, yields a cfg that contains only the
+    expert invariant (plus the scaffolding we keep)."""
+    from tla_eval.evaluation.semantics.manual_invariant_evaluator import (
+        StaticConfigGenerator,
+    )
+
+    contaminated = dedent("""\
+        SPECIFICATION Spec
+        CONSTANT Max = 3
+        INVARIANT ModelInvariant
+        PROPERTY ModelProperty
+        CONSTRAINT ModelConstraint
+        ACTION_CONSTRAINT ModelActionConstraint
+        POSTCONDITION ModelPost
+        """)
+
+    stripped = _strip_user_supplied_assertions(contaminated)
+    gen = StaticConfigGenerator()
+    ok, final_cfg, err = gen.generate_config_for_invariant_from_base(
+        stripped, "ExpertInvariant", "safety"
+    )
+
+    assert ok, err
+    # Expert invariant lands.
+    assert "ExpertInvariant" in final_cfg
+    # Every model-supplied assertion/constraint is gone.
+    assert "ModelInvariant" not in final_cfg
+    assert "ModelProperty" not in final_cfg
+    assert "ModelConstraint" not in final_cfg
+    assert "ModelActionConstraint" not in final_cfg
+    assert "ModelPost" not in final_cfg
+    # Scaffolding survives.
+    assert "SPECIFICATION Spec" in final_cfg
+    assert "CONSTANT Max = 3" in final_cfg
+
+
+def test_compose_liveness_property_path_after_strip():
+    """The liveness path composes into a PROPERTY section. Stripping a model
+    PROPERTY first, then adding the expert one, must leave only the expert."""
+    from tla_eval.evaluation.semantics.manual_invariant_evaluator import (
+        StaticConfigGenerator,
+    )
+
+    stripped = _strip_user_supplied_assertions(
+        "SPECIFICATION Spec\nCONSTANT Max = 3\nPROPERTY ModelLiveness\n"
+    )
+    gen = StaticConfigGenerator()
+    ok, final_cfg, err = gen.generate_config_for_invariant_from_base(
+        stripped, "ExpertLiveness", "liveness"
+    )
+
+    assert ok, err
+    assert "ExpertLiveness" in final_cfg
+    assert "ModelLiveness" not in final_cfg
+    assert "SPECIFICATION Spec" in final_cfg
+
+
+def test_compose_from_fully_stripped_base():
+    """A base cfg that was entirely model assertions strips to almost nothing;
+    composition must still produce a valid single expert-invariant section."""
+    from tla_eval.evaluation.semantics.manual_invariant_evaluator import (
+        StaticConfigGenerator,
+    )
+
+    stripped = _strip_user_supplied_assertions(
+        "INVARIANT ModelA\nPROPERTY ModelB\n"
+    )
+    gen = StaticConfigGenerator()
+    ok, final_cfg, err = gen.generate_config_for_invariant_from_base(
+        stripped, "ExpertInv", "safety"
+    )
+
+    assert ok, err
+    assert "ExpertInv" in final_cfg
+    assert "ModelA" not in final_cfg
+    assert "ModelB" not in final_cfg
+
+
+# ---------------------------------------------------------------------------
+# Behavioral integration tests: prove the strip actually changes TLC's verdict
+# on the same spec, not just the text of the cfg. Gated on TLC being present.
+# ---------------------------------------------------------------------------
+
+
+_COUNTER_SPEC = dedent(
+    """\
+    ---- MODULE Counter ----
+    EXTENDS Naturals
+    VARIABLE x
+
+    Init == x = 0
+    Next == /\\ x < 20
+            /\\ x' = x + 1
+    Spec == Init /\\ [][Next]_x
+
+    \\* Expert invariant: actually true throughout the reachable state space.
+    ExpertOK == x \\in Nat
+
+    \\* Model-supplied "halting" invariant: false at x=5.
+    ModelHaltsAt5 == x < 5
+
+    \\* Model-supplied state constraint: caps exploration at x in [0,3].
+    ModelBound == x <= 3
+
+    \\* Expert invariant that should be violated when x reaches 10.
+    ExpertFailsAt10 == x < 10
+    ====
+    """
+)
+
+
+def _run_tlc(work_dir: Path, spec_name: str, cfg_name: str, timeout: int = 60):
+    return subprocess.run(
+        [
+            "java",
+            "-cp",
+            str(_TLC_JAR),
+            "tlc2.TLC",
+            "-workers",
+            "1",
+            "-config",
+            cfg_name,
+            spec_name,
+        ],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _compose(base_cfg: str, invariant_name: str) -> str:
+    """Mirror the production flow: hand a base cfg to StaticConfigGenerator
+    and ask it to add the expert invariant. Used by the behavioral tests to
+    build the cfg that would actually reach TLC."""
+    from tla_eval.evaluation.semantics.manual_invariant_evaluator import (
+        StaticConfigGenerator,
+    )
+
+    gen = StaticConfigGenerator()
+    ok, final_cfg, err = gen.generate_config_for_invariant_from_base(
+        base_cfg, invariant_name, "safety"
+    )
+    assert ok, err
+    return final_cfg
+
+
+@pytest.mark.skipif(not _TLC_AVAILABLE, reason=_TLC_SKIP_REASON)
+def test_strip_changes_tlc_verdict_for_invariant_contamination(tmp_path):
+    """A model-supplied INVARIANT carried in the base cfg ends up alongside
+    the expert invariant in the cfg sent to TLC. If the model's invariant
+    is the first to be violated, TLC halts and the per-template parser
+    attributes the violation to the expert invariant's run — a false FAIL.
+    Stripping the base cfg before composition removes the contamination."""
+    (tmp_path / "Counter.tla").write_text(_COUNTER_SPEC)
+
+    base = dedent(
+        """\
+        SPECIFICATION Spec
+        INVARIANT ModelHaltsAt5
+        """
+    )
+
+    contaminated_final = _compose(base, "ExpertOK")
+    clean_final = _compose(_strip_user_supplied_assertions(base), "ExpertOK")
+
+    # Sanity: contaminated cfg carries the model's invariant; clean one doesn't.
+    assert "ModelHaltsAt5" in contaminated_final
+    assert "ExpertOK" in contaminated_final
+    assert "ModelHaltsAt5" not in clean_final
+    assert "ExpertOK" in clean_final
+
+    (tmp_path / "contam.cfg").write_text(contaminated_final)
+    (tmp_path / "clean.cfg").write_text(clean_final)
+
+    contam_run = _run_tlc(tmp_path, "Counter", "contam.cfg")
+    clean_run = _run_tlc(tmp_path, "Counter", "clean.cfg")
+
+    # Contaminated: TLC halts on the model's invariant before it can issue a
+    # clean verdict on ExpertOK. Violation message names ModelHaltsAt5.
+    assert contam_run.returncode != 0
+    assert "Invariant ModelHaltsAt5 is violated" in contam_run.stdout
+    assert "Invariant ExpertOK is violated" not in contam_run.stdout
+
+    # Clean: TLC explores the full reachable space, ExpertOK holds throughout.
+    assert "is violated" not in clean_run.stdout
+
+
+@pytest.mark.skipif(not _TLC_AVAILABLE, reason=_TLC_SKIP_REASON)
+def test_strip_changes_tlc_verdict_for_constraint_contamination(tmp_path):
+    """A model-supplied CONSTRAINT carried in the base cfg shrinks the state
+    space TLC explores. If the constraint excludes the states that would
+    falsify the expert invariant, the invariant "passes" — a false PASS.
+    Stripping the base cfg restores full coverage."""
+    (tmp_path / "Counter.tla").write_text(_COUNTER_SPEC)
+
+    base = dedent(
+        """\
+        SPECIFICATION Spec
+        CONSTRAINT ModelBound
+        """
+    )
+
+    contaminated_final = _compose(base, "ExpertFailsAt10")
+    clean_final = _compose(_strip_user_supplied_assertions(base), "ExpertFailsAt10")
+
+    # Sanity: CONSTRAINT survives in contaminated, gone in clean.
+    assert "ModelBound" in contaminated_final
+    assert "CONSTRAINT" in contaminated_final
+    assert "ModelBound" not in clean_final
+    assert "CONSTRAINT" not in clean_final
+
+    (tmp_path / "contam.cfg").write_text(contaminated_final)
+    (tmp_path / "clean.cfg").write_text(clean_final)
+
+    contam_run = _run_tlc(tmp_path, "Counter", "contam.cfg")
+    clean_run = _run_tlc(tmp_path, "Counter", "clean.cfg")
+
+    # Contaminated: ModelBound caps x at 3, TLC never reaches x=10,
+    # ExpertFailsAt10 "passes" — false negative.
+    assert "is violated" not in contam_run.stdout
+
+    # Clean: TLC reaches x=10 and catches the real violation.
+    assert "Invariant ExpertFailsAt10 is violated" in clean_run.stdout
+
+
+@pytest.mark.skipif(not _TLC_AVAILABLE, reason=_TLC_SKIP_REASON)
+def test_strip_changes_tlc_verdict_for_block_comment_invariant(tmp_path):
+    """TLC honors a section keyword preceded by an inline `(* ... *)` block
+    comment, so a model can carry one in its base cfg. Left unstripped it
+    contaminates the expert run (false FAIL); the comment-aware strip removes
+    it."""
+    (tmp_path / "Counter.tla").write_text(_COUNTER_SPEC)
+
+    base = dedent(
+        """\
+        SPECIFICATION Spec
+        (* model note *) INVARIANT ModelHaltsAt5
+        """
+    )
+
+    contaminated_final = _compose(base, "ExpertOK")
+    clean_final = _compose(_strip_user_supplied_assertions(base), "ExpertOK")
+
+    assert "ModelHaltsAt5" in contaminated_final
+    assert "ModelHaltsAt5" not in clean_final
+    assert "ExpertOK" in clean_final
+
+    (tmp_path / "contam.cfg").write_text(contaminated_final)
+    (tmp_path / "clean.cfg").write_text(clean_final)
+
+    contam_run = _run_tlc(tmp_path, "Counter", "contam.cfg")
+    clean_run = _run_tlc(tmp_path, "Counter", "clean.cfg")
+
+    # Contaminated: TLC parses and enforces the commented-prefixed model
+    # invariant, halting before ExpertOK gets a clean verdict.
+    assert "Invariant ModelHaltsAt5 is violated" in contam_run.stdout
+    # Clean: only ExpertOK remains, and it holds throughout.
+    assert "is violated" not in clean_run.stdout

--- a/tla_eval/evaluation/semantics/manual_invariant_evaluator.py
+++ b/tla_eval/evaluation/semantics/manual_invariant_evaluator.py
@@ -39,18 +39,6 @@ class InvariantTemplate:
     tla_example: str
 
 
-@dataclass  
-class InvariantTestResult:
-    """Result of testing a single invariant"""
-    name: str
-    success: bool
-    translated_invariant: str
-    error_message: Optional[str] = None
-    states_explored: int = 0
-    verification_time: float = 0.0
-    tlc_output: str = ""
-
-
 class InvariantTemplateLoader:
     """Loads invariant templates from YAML files"""
     
@@ -1018,83 +1006,6 @@ class ManualInvariantEvaluator(BaseEvaluator):
             result.invariant_generation_error = str(e)
             result.overall_success = False
             return result
-    
-    def _test_single_invariant(self, 
-                              template: InvariantTemplate,
-                              translated_invariant: str, 
-                              tla_content: str,
-                              output_dir: Path,
-                              spec_module: str,
-                              task_name: str,
-                              model_name: str,
-                              base_config: str) -> InvariantTestResult:
-        """Test a single invariant using TLC"""
-        
-        logger.debug(f"Testing invariant: {template.name}")
-        
-        try:
-            # Create directory for this invariant
-            invariant_dir = output_dir / template.name
-            invariant_dir.mkdir(exist_ok=True)
-            
-            # Create modified TLA+ spec with the invariant
-            modified_spec = self._add_invariant_to_spec(
-                tla_content, translated_invariant, template.name
-            )
-            
-            # Save modified spec with correct module name
-            modified_spec_file = invariant_dir / f"{spec_module}.tla"
-            with open(modified_spec_file, 'w', encoding='utf-8') as f:
-                f.write(modified_spec)
-            
-            # Generate config file for this invariant using pre-generated clean base config
-            # This prevents cache pollution from using modified_spec
-            config_success, config_content, config_error = self.static_config_generator.generate_config_for_invariant_from_base(
-                base_config, template.name, template.type
-            )
-            
-            if not config_success:
-                return InvariantTestResult(
-                    name=template.name,
-                    success=False,
-                    translated_invariant=translated_invariant,
-                    error_message=f"Config generation failed: {config_error}"
-                )
-            
-            # Save config file with correct module name
-            config_file = invariant_dir / f"{spec_module}.cfg"
-            with open(config_file, 'w', encoding='utf-8') as f:
-                f.write(config_content)
-            
-            # Run TLC (skip statistics recording for invariant checking, add -deadlock flag)
-            start_time = time.time()
-            tlc_success, tlc_output, tlc_exit_code = self.tlc_runner.run_model_checking(
-                str(modified_spec_file), str(config_file), record_stats=False, use_deadlock_flag=True
-            )
-            verification_time = time.time() - start_time
-            
-            # Parse TLC results
-            violations, deadlock_found, states_explored = self.tlc_runner.parse_tlc_output(tlc_output)
-            
-            success = tlc_success and len(violations) == 0 and not deadlock_found
-            
-            return InvariantTestResult(
-                name=template.name,
-                success=success,
-                translated_invariant=translated_invariant,
-                states_explored=states_explored,
-                verification_time=verification_time,
-                tlc_output=tlc_output,
-                error_message=None if success else f"TLC failed: {len(violations)} violations, deadlock: {deadlock_found}"
-            )
-            
-        except Exception as e:
-            return InvariantTestResult(
-                name=template.name,
-                success=False,
-                translated_invariant=translated_invariant,
-                error_message=f"Testing failed: {str(e)}"
-            )
     
     def _add_invariant_to_spec(self, tla_content: str, invariant_definition: str, invariant_name: str) -> str:
         """Add a single invariant definition to the TLA+ specification"""

--- a/tla_eval/languages/tla_plus.py
+++ b/tla_eval/languages/tla_plus.py
@@ -26,6 +26,168 @@ from .result_types import (
 logger = logging.getLogger(__name__)
 
 
+# TLC config keywords that start a new section. Used to detect when a
+# continuation line in a dropped section gives way to a section we keep.
+# Source of truth: the keyword constants in TLC's `tlc2.tool.impl.ModelConfig`
+# (the full set, including the singular/plural pairs and the experimental
+# RL-guided directives). Every variant must be listed or an unrecognized
+# header is misread as a continuation line of the preceding section.
+_TLC_CFG_SECTION_KEYWORDS = frozenset(
+    {
+        "SPECIFICATION",
+        "INIT",
+        "NEXT",
+        "CONSTANT",
+        "CONSTANTS",
+        "INVARIANT",
+        "INVARIANTS",
+        "PROPERTY",
+        "PROPERTIES",
+        "CONSTRAINT",
+        "CONSTRAINTS",
+        "ACTION_CONSTRAINT",
+        "ACTION_CONSTRAINTS",
+        "SYMMETRY",
+        "VIEW",
+        "ALIAS",
+        "POSTCONDITION",
+        "POSTCONDITIONS",
+        "CHECK_DEADLOCK",
+        # Experimental RL-guided model-checking directives. Not assertions, so
+        # they are kept (absent from _TLC_USER_ASSERTION_KEYWORDS); listed here
+        # only so they are recognized as section boundaries.
+        "_PERIODIC",
+        "_POSSIBLE",
+        "_RL_REWARD",
+    }
+)
+
+# Sections whose contents are model-supplied assertions or state-space
+# constraints. Stripped from the base .cfg before composing the per-expert-
+# invariant cfg passed to TLC (see `_strip_user_supplied_assertions`).
+_TLC_USER_ASSERTION_KEYWORDS = frozenset(
+    {
+        "INVARIANT",
+        "INVARIANTS",
+        "PROPERTY",
+        "PROPERTIES",
+        "CONSTRAINT",
+        "CONSTRAINTS",
+        "ACTION_CONSTRAINT",
+        "ACTION_CONSTRAINTS",
+        "POSTCONDITION",
+        "POSTCONDITIONS",
+    }
+)
+
+
+def _decomment_cfg_line(line: str, block_depth: int) -> Tuple[str, int]:
+    """Return ``(code, new_block_depth)`` for one .cfg line.
+
+    ``code`` is ``line`` with TLC comments removed: ``\\*`` line comments (to
+    end of line) and ``(* ... *)`` block comments, the latter possibly spanning
+    multiple lines and nesting. ``block_depth`` carries how many ``(*`` are open
+    from previous lines. Used only to classify a line (header vs continuation),
+    never to build the output, so comments on kept lines are preserved verbatim.
+
+    TLC tokenizes the whole .cfg with the TLA+ lexer, so a keyword inside a
+    comment is not a section header; classifying on de-commented text matches
+    that. (Comment handling is approximate, not a full TLA+ lexer: it does not
+    track string literals, but .cfg files have none in practice.)
+    """
+    out_chars: List[str] = []
+    i, n = 0, len(line)
+    while i < n:
+        pair = line[i : i + 2]
+        if block_depth > 0:
+            if pair == "*)":
+                block_depth -= 1
+                i += 2
+            elif pair == "(*":
+                block_depth += 1
+                i += 2
+            else:
+                i += 1
+            continue
+        if pair == "(*":
+            block_depth += 1
+            i += 2
+        elif pair == "\\*":
+            break  # line comment runs to end of line
+        else:
+            out_chars.append(line[i])
+            i += 1
+    return "".join(out_chars), block_depth
+
+
+def _strip_user_supplied_assertions(cfg: str) -> str:
+    """Remove model-supplied assertion/constraint sections from a TLC .cfg.
+
+    Phase-4 invariant_verification composes a per-invariant cfg by appending
+    the (translated) expert invariant to a base cfg. If the base cfg already
+    carries the model's own INVARIANT / PROPERTY / CONSTRAINT /
+    ACTION_CONSTRAINT / POSTCONDITION sections, two things go wrong:
+
+    - TLC can halt on the model's assertion before the expert invariant gets
+      a clean verdict, leaving the expert one effectively unmeasured.
+    - A model-supplied CONSTRAINT or ACTION_CONSTRAINT can shrink the
+      reachable state space enough to silently mask paths that would
+      otherwise violate the expert invariant.
+
+    This applies to every method whose phase-2 cfg flows into phase-3 via
+    --config-file, not just BYO methods that emit their own cfg.
+
+    Drops the header and continuation lines of those sections (including any
+    comments inside them). Keeps SPECIFICATION, INIT, NEXT, CONSTANT(S),
+    SYMMETRY, VIEW, ALIAS, CHECK_DEADLOCK and the experimental RL directives,
+    plus comments and blank lines outside dropped sections.
+
+    Classification is line-based but comment-aware (see _decomment_cfg_line)
+    and treats a keyword line as a section header only when it is not an
+    assignment, so a constant whose name collides with an assertion keyword
+    (e.g. ``PROPERTY = TRUE`` under CONSTANT) is not mistaken for a section.
+    Known limitation: TLC's .cfg grammar is fully whitespace-insensitive, so a
+    pathological layout that this line scanner cannot disambiguate may still be
+    mis-stripped; the cases above cover every form seen in generated specs.
+    """
+    cfg = cfg.replace("\r\n", "\n").replace("\r", "\n")
+    out: List[str] = []
+    in_dropped_section = False
+    block_depth = 0
+
+    for line in cfg.split("\n"):
+        code, block_depth = _decomment_cfg_line(line, block_depth)
+        stripped = code.strip()
+
+        # Blank or comment-only line: keep it only outside a dropped section so
+        # a comment that annotated a stripped section does not dangle.
+        if not stripped:
+            if not in_dropped_section:
+                out.append(line)
+            continue
+
+        first = stripped.split()[0]
+        # A section header is `KEYWORD` or `KEYWORD names...`. An assertion
+        # keyword followed by an assignment is a constant binding whose name
+        # collides with the keyword, not a real section, so don't treat it as
+        # a header. CONSTANT(S) legitimately use `=`, so they are exempt.
+        looks_like_binding = "=" in stripped or "<-" in stripped
+        is_header = first in _TLC_CFG_SECTION_KEYWORDS and not (
+            first in _TLC_USER_ASSERTION_KEYWORDS and looks_like_binding
+        )
+        if is_header:
+            in_dropped_section = first in _TLC_USER_ASSERTION_KEYWORDS
+            if not in_dropped_section:
+                out.append(line)
+            continue
+
+        # Continuation / binding line of the current section.
+        if not in_dropped_section:
+            out.append(line)
+
+    return "\n".join(out).rstrip() + "\n"
+
+
 class TLAPlusBackend(LanguageBackend):
     name = "TLA+"
     aliases = ("tla+", "tla", "tlaplus", "tla_plus")
@@ -249,6 +411,12 @@ class TLAPlusBackend(LanguageBackend):
 
         spec_text = spec_path.read_text(encoding="utf-8")
         base_config = config_path.read_text(encoding="utf-8")
+        # The base cfg may carry the model's own INVARIANT / PROPERTY /
+        # CONSTRAINT / ACTION_CONSTRAINT / POSTCONDITION sections (the
+        # phase-2 cfg is forwarded into phase-3 via --config-file). Those
+        # contaminate the per-expert-invariant check, so strip them before
+        # composing the cfg sent to TLC.
+        base_config = _strip_user_supplied_assertions(base_config)
 
         evaluator = ManualInvariantEvaluator(tlc_timeout=timeout)
         evaluator.tlc_runner = TLCRunner(timeout=timeout)

--- a/tla_eval/languages/tla_plus.py
+++ b/tla_eval/languages/tla_plus.py
@@ -152,6 +152,7 @@ def _strip_user_supplied_assertions(cfg: str) -> str:
     """
     cfg = cfg.replace("\r\n", "\n").replace("\r", "\n")
     out: List[str] = []
+    dropped: List[str] = []
     in_dropped_section = False
     block_depth = 0
 
@@ -177,13 +178,25 @@ def _strip_user_supplied_assertions(cfg: str) -> str:
         )
         if is_header:
             in_dropped_section = first in _TLC_USER_ASSERTION_KEYWORDS
-            if not in_dropped_section:
+            if in_dropped_section:
+                dropped.append(first)
+            else:
                 out.append(line)
             continue
 
         # Continuation / binding line of the current section.
         if not in_dropped_section:
             out.append(line)
+
+    # Log when the base cfg actually carried model-supplied sections, so a
+    # later shift in phase-4 invariant_verification numbers is traceable to
+    # exactly which sections were stripped from which spec's base cfg.
+    if dropped:
+        logger.info(
+            "Stripped %d model-supplied assertion/constraint section(s) from base cfg: %s",
+            len(dropped),
+            ", ".join(dropped),
+        )
 
     return "\n".join(out).rstrip() + "\n"
 


### PR DESCRIPTION
## Problem

Follow-up to the cfg discussion on #16. Phase-4 `invariant_verification` builds its per-invariant cfg by appending the translated expert invariant to a base cfg. That base cfg is the model's own phase-2 cfg, forwarded into phase 3 via `--config-file`, so it can already carry the model's own `INVARIANT` / `PROPERTY` / `CONSTRAINT` / `ACTION_CONSTRAINT` / `POSTCONDITION` sections.

When it does, the expert check is contaminated two ways:

- TLC can halt on the model's own assertion before the expert invariant gets a clean verdict (false FAIL).
- A model `CONSTRAINT` or `ACTION_CONSTRAINT` shrinks the reachable state space, so a path that would violate the expert invariant is never explored (false PASS).

As @Qian-Cheng-nju pointed out, this is not BYO-only. The batch pipeline always forwards the phase-2 cfg to phase 3, so any model whose phase-2 cfg carries these sections is affected. Invariant-verification numbers may move once this lands.

## Fix

New `_strip_user_supplied_assertions` in `tla_eval/languages/tla_plus.py`, called from `check_invariants` before the per-invariant cfg is composed. It removes the assertion and constraint sections and keeps the scaffolding (`SPECIFICATION`, `INIT`, `NEXT`, `CONSTANT(S)`, `SYMMETRY`, `VIEW`, `ALIAS`, `CHECK_DEADLOCK`).

Beyond the minimal strip:

- Both singular and plural keyword forms are handled. The keyword set comes from TLC's `tlc2.tool.impl.ModelConfig` so it does not drift. That file lists both `ACTION_CONSTRAINT` and `ACTION_CONSTRAINTS`, and both `POSTCONDITION` and `POSTCONDITIONS`, so all of those are covered.
- Classification is comment-aware. TLC tokenizes the whole cfg with the TLA+ lexer, so a keyword only starts a section at the token level. The strip removes `\*` line comments and `(* ... *)` block comments (including multi-line) before deciding what a line is, so `(* note *) INVARIANT Foo`, which TLC does honor, gets stripped instead of kept.
- A keyword line counts as a header only when it is not an assignment, so a constant binding whose name collides with a keyword (for example `PROPERTY = TRUE` under `CONSTANT`) is preserved instead of silently dropped.
- Comments that sit inside a dropped section are dropped with it instead of dangling, and CRLF input is normalized.

## Tests

`tests/test_languages/test_tla_plus.py`. Unit tests cover one-liner and block forms, singular and plural keywords, inline and multi-line block comments, the keyword-as-constant-name case, comment handling, and idempotency. Composition tests cover the safety and liveness paths and a base that strips to nothing. Three TLC-gated behavioral tests run the bundled `lib/tla2tools.jar` and show the verdict actually changes: a model `INVARIANT` (plain and comment-prefixed) turns a false FAIL into a clean pass, and a model `CONSTRAINT` turns a false PASS into the real violation. They skip cleanly if the jar or `java` is missing.

Run with `pytest tests/test_languages/test_tla_plus.py`.

## Known limitations

The strip is a comment-aware line scanner, not a full TLA+ tokenizer. TLC's cfg grammar is fully whitespace-insensitive, so a sufficiently odd layout could still be classified wrong. I checked the realistic forms above and every `.cfg` in the repo (they all use `\*` line comments and none name a constant after a keyword), and those are handled. The experimental RL directives (`_PERIODIC`, `_POSSIBLE`, `_RL_REWARD`) are recognized as section boundaries but not stripped, since they are not assertions and a spec generator will not emit them. If you would prefer a tokenizer-faithful version that removes the whole class of edge cases, I can do that, it is just more code for input that does not occur today.

## Notes, out of scope here

- There is no CI job running pytest (only `docker-publish.yml`), so this suite runs manually for now. I can add a small test workflow in a separate PR if that is useful.
- `_test_single_invariant` in `manual_invariant_evaluator.py` is dead code and composes a cfg without the strip. It is not on any live path, so I left it alone, but it is worth removing or routing through the strip later.
